### PR TITLE
2 "fixes" for the oled compiler error

### DIFF
--- a/ssd1306.c
+++ b/ssd1306.c
@@ -74,12 +74,12 @@ bool ssd1306_init(ssd1306_t *p, uint16_t width, uint16_t height, uint8_t address
 
 
     p->bufsize=(p->pages)*(p->width);
-    if((p->buffer=malloc(p->bufsize+1))==NULL) {
+    if((p->mbuffer=malloc(p->bufsize+1))==NULL) {
         p->bufsize=0;
         return false;
     }
 
-    ++(p->buffer);
+    p->buffer = p->mbuffer + 1;
 
     // from https://github.com/makerportal/rpi-pico-ssd1306
     uint8_t cmds[]= {
@@ -123,9 +123,9 @@ bool ssd1306_init(ssd1306_t *p, uint16_t width, uint16_t height, uint8_t address
 
 inline void ssd1306_deinit(ssd1306_t *p)
 {
-    if (p->buffer - 1)
+    if ( p->mbuffer )
     {
-        free(p->buffer - 1);
+        free(p->mbuffer);
     }
 }
 
@@ -309,9 +309,9 @@ void ssd1306_show(ssd1306_t *p)
         for (size_t i = 0; i < sizeof(payload); ++i)
             ssd1306_write(p, payload[i]);
 
-        tmp = p->buffer[page * p->width - 1];
-        p->buffer[page * p->width - 1] = 0x40;
-        fancy_write(p->i2c_i, p->address, &p->buffer[page * p->width - 1], p->width + 1, "ssd1306_show");
-        p->buffer[page * p->width - 1] = tmp;
+        tmp = p->mbuffer[page * p->width];
+        p->mbuffer[page * p->width] = 0x40;
+        fancy_write(p->i2c_i, p->address, &p->mbuffer[page * p->width], p->width + 1, "ssd1306_show");
+        p->mbuffer[page * p->width] = tmp;
     }
 }

--- a/ssd1306.h
+++ b/ssd1306.h
@@ -71,6 +71,7 @@ typedef struct {
     i2c_inst_t *i2c_i; 	/**< i2c connection instance */
     bool external_vcc; 	/**< whether display uses external vcc */ 
     uint8_t *buffer;	/**< display buffer */
+    uint8_t *mbuffer;	/**< display buffer */
     size_t bufsize;		/**< buffer size */
 } ssd1306_t;
 

--- a/ssd1306.h
+++ b/ssd1306.h
@@ -71,7 +71,6 @@ typedef struct {
     i2c_inst_t *i2c_i; 	/**< i2c connection instance */
     bool external_vcc; 	/**< whether display uses external vcc */ 
     uint8_t *buffer;	/**< display buffer */
-    uint8_t *mbuffer;	/**< display buffer */
     size_t bufsize;		/**< buffer size */
 } ssd1306_t;
 

--- a/ui.cpp
+++ b/ui.cpp
@@ -1167,6 +1167,10 @@ bool ui::do_ui(bool rx_settings_changed)
           enumerate_entry("USB Firmware Upgrade", "No#Yes#", 1, &setting);
           if(setting)
           {
+            display_clear();
+            display_print("Ready for upload...");
+            display_show();
+
             reset_usb_boot(0,0);
           }
           break;


### PR DESCRIPTION
fix compiler warning/error on ssd1306_deinit
also used a 2nd pointer to clean up some of the repeated "-1" in the show function

I then went on to another fix for oled writing:
This time we allocate 129 bytes per page to make room for the 0x40 at the start of each I2C transmission
