### PR TITLE
Some adjustments around FFT calculation + minor fixes

### DIFF
--- a/picorx.cpp
+++ b/picorx.cpp
@@ -30,7 +30,6 @@ int main()
   {
     uint32_t _time_us = time_us_32();
     user_interface.do_ui();
-    sleep_us(100000);
     _time_us = time_us_32() - _time_us;
     if (_time_us < UI_REFRESH_US)
       sleep_us(UI_REFRESH_US - _time_us);

--- a/rx.cpp
+++ b/rx.cpp
@@ -317,10 +317,9 @@ void rx::run()
 
           //process adc data as each block completes
           dma_channel_wait_for_finish_blocking(adc_dma_ping);
-          clock_t start_time;
-          start_time = time_us_64();
+          uint32_t start_time = time_us_32();
           num_ping_samples = rx_dsp_inst.process_block(ping_samples, ping_audio);
-          busy_time = time_us_64()-start_time;
+          busy_time = time_us_32()-start_time;
           dma_channel_wait_for_finish_blocking(adc_dma_pong);
           num_pong_samples = rx_dsp_inst.process_block(pong_samples, pong_audio);
       }

--- a/rx.h
+++ b/rx.h
@@ -35,7 +35,7 @@ struct rx_settings
 struct rx_status
 {
   int32_t signal_strength_dBm;
-  clock_t busy_time;
+  uint32_t busy_time;
   uint16_t temp;
   uint16_t battery;
 };
@@ -86,7 +86,7 @@ class rx
   static void dma_handler();
   
   //store busy time for performance monitoring
-  clock_t busy_time;
+  uint32_t busy_time;
 
   public:
   rx(rx_settings & settings_to_apply, rx_status & status);


### PR DESCRIPTION
I know that some people are not huge fans of using const LUTs, but saves some memory and often compute.
Also added few small fixes/adjustments. time_us_32() overflows after more than an hour, so is enough for measuring momentary utilization.