### PR TITLE
Menus now use double size font

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 test_dsp
+*~

--- a/ssd1306.c
+++ b/ssd1306.c
@@ -150,6 +150,10 @@ inline void ssd1306_flip(ssd1306_t *p, uint8_t flip) {
     }
 }
 
+inline void ssd1306_clear(ssd1306_t *p, bool colour) {
+    memset(p->buffer, 0xff*colour, p->bufsize);
+}
+
 inline void ssd1306_type(ssd1306_t *p, uint8_t type) {
     if (type) {
         p->disp_col_offset = 2;
@@ -158,17 +162,19 @@ inline void ssd1306_type(ssd1306_t *p, uint8_t type) {
     }
 }
 
-inline void ssd1306_clear(ssd1306_t *p) {
-    memset(p->buffer, 0, p->bufsize);
-}
 
-void ssd1306_draw_pixel(ssd1306_t *p, uint32_t x, uint32_t y) {
+void ssd1306_draw_pixel(ssd1306_t *p, uint32_t x, uint32_t y, bool colour) {
     if(x>=p->width || y>=p->height) return;
+
     // each page is 129 bytes long for the oled cmd byte at the start
-    p->buffer[1 + x + (1 + p->width)*(y>>3) ] |= 0x1<<(y&0x07); // y>>3==y/8 && y&0x7==y%8
+    if (colour) {
+        p->buffer[1 + x + (1 + p->width)*(y>>3) ] |= 0x1<<(y&0x07); // y>>3==y/8 && y&0x7==y%8
+    } else {
+        p->buffer[1 + x + (1 + p->width)*(y>>3) ] &= ~(0x1<<(y&0x07)); // y>>3==y/8 && y&0x7==y%8
+    }
 }
 
-void ssd1306_draw_line(ssd1306_t *p, int32_t x1, int32_t y1, int32_t x2, int32_t y2) {
+void ssd1306_draw_line(ssd1306_t *p, int32_t x1, int32_t y1, int32_t x2, int32_t y2, bool colour) {
     if(x1>x2) {
         swap(&x1, &x2);
         swap(&y1, &y2);
@@ -178,7 +184,7 @@ void ssd1306_draw_line(ssd1306_t *p, int32_t x1, int32_t y1, int32_t x2, int32_t
         if(y1>y2)
             swap(&y1, &y2);
         for(int32_t i=y1; i<=y2; ++i)
-            ssd1306_draw_pixel(p, x1, i);
+            ssd1306_draw_pixel(p, x1, i, colour);
         return;
     }
 
@@ -186,27 +192,29 @@ void ssd1306_draw_line(ssd1306_t *p, int32_t x1, int32_t y1, int32_t x2, int32_t
 
     for(int32_t i=x1; i<=x2; ++i) {
         float y=m*(float) (i-x1)+(float) y1;
-        ssd1306_draw_pixel(p, i, (uint32_t) y);
+        ssd1306_draw_pixel(p, i, (uint32_t) y, colour);
     }
 }
 
-void ssd1306_draw_square(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t width, uint32_t height) {
+void ssd1306_draw_square(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t width, uint32_t height, bool colour) {
     for(uint32_t i=0; i<width; ++i)
         for(uint32_t j=0; j<height; ++j)
-            ssd1306_draw_pixel(p, x+i, y+j);
+            ssd1306_draw_pixel(p, x+i, y+j, colour);
 
 }
 
-void ssd13606_draw_empty_square(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t width, uint32_t height) {
-    ssd1306_draw_line(p, x, y, x+width, y);
-    ssd1306_draw_line(p, x, y+height, x+width, y+height);
-    ssd1306_draw_line(p, x, y, x, y+height);
-    ssd1306_draw_line(p, x+width, y, x+width, y+height);
+void ssd13606_draw_empty_square(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t width, uint32_t height, bool colour) {
+    ssd1306_draw_line(p, x, y, x+width, y, colour);
+    ssd1306_draw_line(p, x, y+height, x+width, y+height, colour);
+    ssd1306_draw_line(p, x, y, x, y+height, colour);
+    ssd1306_draw_line(p, x+width, y, x+width, y+height, colour);
 }
 
-void ssd1306_draw_char_with_font(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t scale, const uint8_t *font, char c) {
+void ssd1306_draw_char_with_font(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t scale, const uint8_t *font, char c, bool colour) {
     if(c<font[3]||c>font[4])
         return;
+
+    ssd1306_draw_square( p, x, y, (font[1]+font[2])*scale, font[0]*scale, !colour);
 
     uint32_t parts_per_line=(font[0]>>3)+((font[0]&7)>0);
     for(uint8_t w=0; w<font[1]; ++w) { // width
@@ -216,7 +224,7 @@ void ssd1306_draw_char_with_font(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t 
 
             for(int8_t j=0; j<8; ++j, line>>=1) {
                 if(line & 1)
-                    ssd1306_draw_square(p, x+w*scale, y+((lp<<3)+j)*scale, scale, scale);
+                    ssd1306_draw_square(p, x+w*scale, y+((lp<<3)+j)*scale, scale, scale, colour);
             }
 
             ++pp;
@@ -224,18 +232,18 @@ void ssd1306_draw_char_with_font(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t 
     }
 }
 
-void ssd1306_draw_string_with_font(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t scale, const uint8_t *font, const char *s) {
+void ssd1306_draw_string_with_font(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t scale, const uint8_t *font, const char *s, bool colour) {
     for(int32_t x_n=x; *s; x_n+=(font[1]+font[2])*scale) {
-        ssd1306_draw_char_with_font(p, x_n, y, scale, font, *(s++));
+        ssd1306_draw_char_with_font(p, x_n, y, scale, font, *(s++), colour);
     }
 }
 
-void ssd1306_draw_char(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t scale, char c) {
-    ssd1306_draw_char_with_font(p, x, y, scale, font_8x5, c);
+void ssd1306_draw_char(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t scale, char c, bool colour) {
+    ssd1306_draw_char_with_font(p, x, y, scale, font_8x5, c, colour);
 }
 
-void ssd1306_draw_string(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t scale, const char *s) {
-    ssd1306_draw_string_with_font(p, x, y, scale, font_8x5, s);
+void ssd1306_draw_string(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t scale, const char *s, bool colour) {
+    ssd1306_draw_string_with_font(p, x, y, scale, font_8x5, s, colour);
 }
 
 static inline uint32_t ssd1306_bmp_get_val(const uint8_t *data, const size_t offset, uint8_t size) {
@@ -290,7 +298,7 @@ void ssd1306_bmp_show_image_with_offset(ssd1306_t *p, const uint8_t *data, const
     for(uint32_t y=biHeight>0?biHeight-1:0; y!=border; y+=step) {
         for(uint32_t x=0; x<biWidth; ++x) {
             if(((img_data[x>>3]>>(7-(x&7)))&1)==color_val)
-                ssd1306_draw_pixel(p, x_offset+x, y_offset+y);
+                ssd1306_draw_pixel(p, x_offset+x, y_offset+y, 1);
         }
         img_data+=bytes_per_line;
     }

--- a/ssd1306.h
+++ b/ssd1306.h
@@ -164,7 +164,7 @@ void ssd1306_show(ssd1306_t *p);
 	@param[in] p : instance of display
 
 */
-void ssd1306_clear(ssd1306_t *p);
+void ssd1306_clear(ssd1306_t *p, bool colour);
 
 /**
 	@brief draw pixel on buffer
@@ -172,8 +172,9 @@ void ssd1306_clear(ssd1306_t *p);
 	@param[in] p : instance of display
 	@param[in] x : x position
 	@param[in] y : y position
+	@param[in] colour : 1=white, 0=black
 */
-void ssd1306_draw_pixel(ssd1306_t *p, uint32_t x, uint32_t y);
+void ssd1306_draw_pixel(ssd1306_t *p, uint32_t x, uint32_t y, bool colour);
 
 /**
 	@brief draw pixel on buffer
@@ -183,8 +184,9 @@ void ssd1306_draw_pixel(ssd1306_t *p, uint32_t x, uint32_t y);
 	@param[in] y1 : y position of starting point
 	@param[in] x2 : x position of end point
 	@param[in] y2 : y position of end point
+	@param[in] colour : 1=white, 0=black
 */
-void ssd1306_draw_line(ssd1306_t *p, int32_t x1, int32_t y1, int32_t x2, int32_t y2);
+void ssd1306_draw_line(ssd1306_t *p, int32_t x1, int32_t y1, int32_t x2, int32_t y2, bool colour);
 
 /**
 	@brief draw filled square at given position with given size
@@ -194,8 +196,9 @@ void ssd1306_draw_line(ssd1306_t *p, int32_t x1, int32_t y1, int32_t x2, int32_t
 	@param[in] y : y position of starting point
 	@param[in] width : width of square
 	@param[in] height : height of square
+	@param[in] colour : 1=white, 0=black
 */
-void ssd1306_draw_square(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t width, uint32_t height);
+void ssd1306_draw_square(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t width, uint32_t height, bool colour);
 
 /**
 	@brief draw empty square at given position with given size
@@ -205,8 +208,9 @@ void ssd1306_draw_square(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t width, u
 	@param[in] y : y position of starting point
 	@param[in] width : width of square
 	@param[in] height : height of square
+	@param[in] colour : 1=white, 0=black
 */
-void ssd13606_draw_empty_square(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t width, uint32_t height);
+void ssd13606_draw_empty_square(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t width, uint32_t height, bool colour);
 
 /**
 	@brief draw monochrome bitmap with offset
@@ -237,8 +241,9 @@ void ssd1306_bmp_show_image(ssd1306_t *p, const uint8_t *data, const long size);
 	@param[in] scale : scale font to n times of original size (default should be 1)
 	@param[in] font : pointer to font
 	@param[in] c : character to draw
+	@param[in] colour : 1=white, 0=black
 */
-void ssd1306_draw_char_with_font(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t scale, const uint8_t *font, char c);
+void ssd1306_draw_char_with_font(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t scale, const uint8_t *font, char c, bool colour);
 
 /**
 	@brief draw char with builtin font
@@ -248,8 +253,9 @@ void ssd1306_draw_char_with_font(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t 
 	@param[in] y : y starting position of char
 	@param[in] scale : scale font to n times of original size (default should be 1)
 	@param[in] c : character to draw
+	@param[in] colour : 1=white, 0=black
 */
-void ssd1306_draw_char(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t scale, char c);
+void ssd1306_draw_char(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t scale, char c, bool colour);
 
 /**
 	@brief draw string with given font
@@ -260,8 +266,10 @@ void ssd1306_draw_char(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t scale, cha
 	@param[in] scale : scale font to n times of original size (default should be 1)
 	@param[in] font : pointer to font
 	@param[in] s : text to draw
+	@param[in] colour : 1=white, 0=black
+
 */
-void ssd1306_draw_string_with_font(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t scale, const uint8_t *font, const char *s );
+void ssd1306_draw_string_with_font(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t scale, const uint8_t *font, const char *s, bool colour);
 
 /**
 	@brief draw string with builtin font
@@ -271,8 +279,9 @@ void ssd1306_draw_string_with_font(ssd1306_t *p, uint32_t x, uint32_t y, uint32_
 	@param[in] y : y starting position of text
 	@param[in] scale : scale font to n times of original size (default should be 1)
 	@param[in] s : text to draw
+	@param[in] colour : 1=white, 0=black
 */
-void ssd1306_draw_string(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t scale, const char *s);
+void ssd1306_draw_string(ssd1306_t *p, uint32_t x, uint32_t y, uint32_t scale, const char *s, bool colour);
 
 
 #ifdef __cplusplus

--- a/ui.h
+++ b/ui.h
@@ -47,6 +47,13 @@ const uint8_t PIN_DISPLAY_SCL = 19;
 
 enum e_button_state {idle, down, fast_mode, menu};
 
+// font styles styles as bits to be ORed
+#define style_normal      0
+#define style_reverse     (1<<0)
+#define style_centered    (1<<1)
+//#define style_bold        (1<<2)
+
+
 class ui
 {
 
@@ -73,18 +80,19 @@ class ui
 
   // Display
   void setup_display();
-  void display_clear();
+  void display_clear(bool colour=0);
   void display_line1();
   void display_line2();
   void display_linen(uint8_t line);
-  void display_write(char x);
-  void display_print(const char str[]);
-  void display_print_num(const char format[], int16_t num);
+  void display_set_xy(uint8_t x, uint8_t y);
+  void display_print_char(char x, uint32_t scale=1, uint32_t style=0);
+  void display_print_str(const char str[], uint32_t scale=1, uint32_t style=0);
+  void display_print_num(const char format[], int16_t num, uint32_t scale=1, uint32_t style=0);
   void display_show();
 
   ssd1306_t disp;
-  uint8_t cursor_x = 0;
-  uint8_t cursor_y = 0;
+  uint8_t cursor_x = 0;   // pixels 0-127
+  uint8_t cursor_y = 0;   // pixels 0-63
 
   // Status                  
   float calculate_signal_strength(rx_status &status);
@@ -93,7 +101,7 @@ class ui
   uint8_t frequency_autosave_timer = 10u;
 
   // Menu                    
-  void print_option(const char options[], uint8_t option);
+  void print_option(const char options[], uint8_t option, uint8_t y_pos);
   uint32_t enumerate_entry(const char title[], const char options[], uint32_t max, uint32_t *value);
   uint32_t bit_entry(const char title[], const char options[], uint8_t bit_position, uint32_t *value);
   int16_t number_entry(const char title[], const char format[], int16_t min, int16_t max, int16_t multiple, uint32_t *value);


### PR DESCRIPTION

s/display_print/display_print_str/ and s/display_write/display_print_char/

display_print_char, display_print_num, display_print_str:
- added a style bitfield. style_reversed style_centered so far

display_print_str:
supports \n for new line
supperts \a to toggle text reverse font

fixed out by 1 error in PSU mode menu

added vim backup files to gitignore