### PR TITLE
More UI rework - recall page, enum's with 2 items

### DIFF
--- a/ssd1306.c
+++ b/ssd1306.c
@@ -141,7 +141,6 @@ inline void ssd1306_invert(ssd1306_t *p, bool inv) {
 }
 
 inline void ssd1306_flip(ssd1306_t *p, bool flip) {
-    printf("into flip %d\n", flip);
     if (flip) {
         ssd1306_write(p, SET_SEG_REMAP | 0x00);
         ssd1306_write(p, SET_COM_OUT_DIR | 0x00);

--- a/ssd1306.c
+++ b/ssd1306.c
@@ -136,11 +136,12 @@ inline void ssd1306_contrast(ssd1306_t *p, uint8_t val) {
     ssd1306_write(p, val);
 }
 
-inline void ssd1306_invert(ssd1306_t *p, uint8_t inv) {
+inline void ssd1306_invert(ssd1306_t *p, bool inv) {
     ssd1306_write(p, SET_NORM_INV | (inv & 1));
 }
 
-inline void ssd1306_flip(ssd1306_t *p, uint8_t flip) {
+inline void ssd1306_flip(ssd1306_t *p, bool flip) {
+    printf("into flip %d\n", flip);
     if (flip) {
         ssd1306_write(p, SET_SEG_REMAP | 0x00);
         ssd1306_write(p, SET_COM_OUT_DIR | 0x00);

--- a/ssd1306.h
+++ b/ssd1306.h
@@ -124,22 +124,22 @@ void ssd1306_poweron(ssd1306_t *p);
 void ssd1306_contrast(ssd1306_t *p, uint8_t val);
 
 /**
-	@brief set invert display
+	@brief set inverted colour display
 
 	@param[in] p : instance of display
 	@param[in] inv : inv==0: disable inverting, inv!=0: invert
 
 */
-void ssd1306_invert(ssd1306_t *p, uint8_t inv);
+void ssd1306_invert(ssd1306_t *p, bool inv);
 
 /**
-	@brief set  display flip (180deg)
+	@brief set 180deg display flip
 
 	@param[in] p : instance of display
 	@param[in] flip : inv==0: disable flipping, inv!=0: flip
 
 */
-void ssd1306_flip(ssd1306_t *p, uint8_t flip);
+void ssd1306_flip(ssd1306_t *p, bool flip);
 
 /**
 	@brief set  display type ssd1306, sh1106

--- a/ui.cpp
+++ b/ui.cpp
@@ -538,6 +538,8 @@ bool ui::upload_memory()
       display_print_str("memories",2, style_centered);
       display_show();
 
+      uint8_t progress_ctr=0;
+
       //work out which flash sector the channel sits in.
       const uint32_t num_channels_per_sector = FLASH_SECTOR_SIZE/(sizeof(int)*chan_size);
 
@@ -575,7 +577,9 @@ bool ui::upload_memory()
             }
           }
         }
-        
+        // show some progress
+        ssd1306_invert( &disp, 0x1 & (++progress_ctr));
+
         //write sector to flash
         const uint32_t address = (uint32_t)&(radio_memory[first_channel_in_sector]);
         const uint32_t flash_address = address - XIP_BASE; 
@@ -601,6 +605,7 @@ bool ui::upload_memory()
 
       }
 
+      ssd1306_invert( &disp, 0);
       return false;
 }
 

--- a/ui.cpp
+++ b/ui.cpp
@@ -530,10 +530,12 @@ void ui::autorestore()
 }
 
 //Upload memories via USB interface
-bool ui::upload()
+bool ui::upload_memory()
 {
       display_clear();
-      display_print_str("Ready for data...");
+      display_print_str("Ready for",2, style_centered);
+      display_print_char('\n', 2);
+      display_print_str("memories",2, style_centered);
       display_show();
 
       //work out which flash sector the channel sits in.
@@ -1129,7 +1131,7 @@ void ui::do_ui(void)
 
       //top level menu
       uint32_t setting = 0;
-      if(!enumerate_entry("menu:", "Frequency#Recall#Store#Volume#Mode#AGC Speed#Squelch#Frequency Step#CW Tone\nFrequency#Regulator Mode#Reverse\nEncoder#Swap IQ#Gain Cal#Flip OLED#OLED Type#USB Memory Upload#USB Firmware Upgrade#", 16, &setting)) return;
+      if(!enumerate_entry("menu:", "Frequency#Recall#Store#Volume#Mode#AGC Speed#Squelch#Frequency Step#CW Tone\nFrequency#Regulator Mode#Reverse\nEncoder#Swap IQ#Gain Cal#Flip OLED#OLED Type#USB Upload#", 15, &setting)) return;
 
       switch(setting)
       {
@@ -1200,27 +1202,20 @@ void ui::do_ui(void)
 
         case 15: 
           setting = 0;
-          enumerate_entry("USB Memory Upload", "No#Yes#", 1, &setting);
-          if(setting)
-          {
-            upload();
-          }
-          break;
-
-        case 16: 
-          setting = 0;
-          enumerate_entry("USB Firmware Upload", "No#Yes#", 1, &setting);
-          if(setting)
-          {
+          enumerate_entry("USB Upload", "Back#Memory#Firmware#", 2, &setting);
+          if(setting==1) {
+            upload_memory();
+          } else if (setting == 2) {
             display_clear();
             display_print_str("Ready for",2, style_centered);
             display_print_char('\n', 2);
-            display_print_str("upload...",2, style_centered);
+            display_print_str("firmware",2, style_centered);
             display_show();
 
-            reset_usb_boot(0,0);
+            reset_usb_boot(0,0);            
           }
           break;
+
       }
       autosave_settings = rx_settings_changed;
     }

--- a/ui.h
+++ b/ui.h
@@ -92,6 +92,7 @@ class ui
   void display_print_char(char x, uint32_t scale=1, uint32_t style=0);
   void display_print_str(const char str[], uint32_t scale=1, uint32_t style=0);
   void display_print_num(const char format[], int16_t num, uint32_t scale=1, uint32_t style=0);
+  void display_print_freq( int32_t frequency, uint32_t scale=1, uint32_t style=0);
   void display_show();
 
   ssd1306_t disp;

--- a/ui.h
+++ b/ui.h
@@ -52,7 +52,9 @@ enum e_button_state {idle, down, fast_mode, menu};
 #define style_reverse     (1<<0)
 #define style_centered    (1<<1)
 #define style_right       (1<<2)
-//#define style_bold        (1<<3)
+#define style_nowrap      (1<<3)
+#define style_trim_spaces       (1<<4)
+//#define style_bold        (1<<?)
 
 
 class ui
@@ -86,6 +88,7 @@ class ui
   void display_line2();
   void display_linen(uint8_t line);
   void display_set_xy(uint8_t x, uint8_t y);
+  void display_add_xy(int8_t x, int8_t y);
   void display_print_char(char x, uint32_t scale=1, uint32_t style=0);
   void display_print_str(const char str[], uint32_t scale=1, uint32_t style=0);
   void display_print_num(const char format[], int16_t num, uint32_t scale=1, uint32_t style=0);

--- a/ui.h
+++ b/ui.h
@@ -110,7 +110,7 @@ class ui
   bool string_entry(char string[]);
   bool recall();
   bool store();
-  bool upload();
+  bool upload_memory();
   void autosave();
   void apply_settings(bool suspend);
 

--- a/ui.h
+++ b/ui.h
@@ -51,7 +51,8 @@ enum e_button_state {idle, down, fast_mode, menu};
 #define style_normal      0
 #define style_reverse     (1<<0)
 #define style_centered    (1<<1)
-//#define style_bold        (1<<2)
+#define style_right       (1<<2)
+//#define style_bold        (1<<3)
 
 
 class ui


### PR DESCRIPTION
Enumerated menus - if only 2 options and they'd fit, print them both with highlight

Reworked Recall page:
- to use 2X fonts for frequency. name is 2X if it'll fit, else 1x
- now skips blank entries when browsing through
- remembers which memory you last selected if you use the menu button
-- if you press the encoder, it sets last memory to 000

Show memory upload progress by inverting the display colours

Consolidated USB upload menus into one menu with 3 entries

fixed bug where oled flip wouldn't do it dynamically under some circumstances

Other internal stuff:

added display_print_freq()
Added style_nowrap. extra characters just get ignored
Added style_trim_spaces which ignores repeat space chars in string
Added style_right to print stuff to..... the right

reworked print_option()
- use strtok to split the options#list#
- if only 2 options and they'd fit, print them both with highlight

Added (harmless) missing trailing # on a couple of enumerate_entry calls
