### PR TITLE
Tidying

### DIFF
--- a/ui.cpp
+++ b/ui.cpp
@@ -169,9 +169,10 @@ void ui::display_print_str(const char str[], uint32_t scale, uint32_t style)
 
       if ( (style & style_centered) && (length < (128/(6*scale))) ) {
         cursor_x = (128- 6*scale*length)/2;
-      }
-      if ( (style & style_right) && (length < (128/(6*scale))) ) {
+      } else if ( (style & style_right) && (length < (128/(6*scale))) ) {
         cursor_x = (128- 6*scale*length);
+      } else {
+        cursor_x = 0;
       }
       cursor_y += 9*scale;
       continue;
@@ -242,7 +243,6 @@ void ui::update_display(rx_status & status, rx & receiver)
   ssd1306_draw_string(&disp, 72, 0, 1, buff, 1);
 
   //mode
-  static const char modes[][4]  = {" AM", "LSB", "USB", " FM", " CW"};
   ssd1306_draw_string(&disp, 102, 0, 1, modes[settings[idx_mode]], 1);
 
   //step
@@ -762,7 +762,6 @@ bool ui::store()
 
       display_print_str("Store");
       display_print_num(" %03i ", select, 1, style_centered);
-      static const char modes[][4]  = {"AM ", "LSB", "USB", "FM ", "CW "};
       display_print_str(modes[settings[idx_mode]],1,style_right);
       display_print_str("\n", 1);
 
@@ -892,7 +891,6 @@ bool ui::recall()
         display_clear();
         display_print_str("Recall");
         display_print_num(" %03i ", select, 1, style_centered);
-        static const char modes[][4]  = {"AM ", "LSB", "USB", "FM ", "CW "};
         display_print_str(modes[radio_memory[select][idx_mode]],1,style_right);
 
         display_print_str("\n", 1);

--- a/ui.cpp
+++ b/ui.cpp
@@ -733,9 +733,20 @@ bool ui::store()
         draw_once = false;
         display_clear();
         display_print_str("Store");
-        display_line2();
-        display_print_num("%03i ", select);
-        display_print_str(name);
+        display_print_num(" %03i ", select, 1, style_centered);
+        display_print_str("\n", 1);
+        // strip trailing spaces
+        for (int i=15; i>=0; i--) {
+          if (name[i] != ' ') break;
+          name[i] = 0;
+        }
+        if (12*strlen(name) > 128) {
+          display_add_xy(0,4);
+          display_print_str(name,1,style_nowrap|style_centered);
+        } else {
+          display_print_str(name,2,style_nowrap|style_centered);
+        }
+
         display_show();
       }
       else
@@ -744,9 +755,9 @@ bool ui::store()
         draw_once = false;
         display_clear();
         display_print_str("Store");
-        display_line2();
-        display_print_num("%03i ", select);
-        display_print_str("BLANK");
+        display_print_num(" %03i ", select, 1, style_centered);
+        display_print_str("\n", 1);
+        display_print_str("BLANK",2,style_nowrap|style_centered);
         display_show();
       }
     }
@@ -1088,10 +1099,11 @@ bool ui::frequency_entry(){
     if(encoder_changed || draw_once)
     {
       draw_once = false;
-      display_clear();
 
       //write frequency to lcd
-      display_line1();
+      display_clear();
+      display_print_str("Frequency",1);
+      display_set_xy(4,9);
       for(i=0; i<8; i++)
       {
         if (!edit_mode && (i==digit)) {

--- a/ui.h
+++ b/ui.h
@@ -98,10 +98,10 @@ class ui
   void display_add_xy(int8_t x, int8_t y);
   void display_print_char(char x, uint32_t scale=1, uint32_t style=0);
   void display_print_str(const char str[], uint32_t scale=1, uint32_t style=0);
-  void display_print_line(const char str[], uint32_t scale=1, uint32_t style=0);
   void display_print_num(const char format[], int16_t num, uint32_t scale=1, uint32_t style=0);
   void display_print_freq(uint32_t frequency, uint32_t scale=1, uint32_t style=0);
   void display_show();
+  int strchr_idx(const char str[], uint8_t c);
 
   ssd1306_t disp;
   uint8_t cursor_x = 0;   // pixels 0-127

--- a/ui.h
+++ b/ui.h
@@ -119,8 +119,8 @@ class ui
   // Menu                    
   void print_enum_option(const char options[], uint8_t option);
   void print_menu_option(const char options[], uint8_t option);
-  uint32_t menu_entry(const char title[], const char options[], uint32_t max, uint32_t *value);
-  uint32_t enumerate_entry(const char title[], const char options[], uint32_t max, uint32_t *value);
+  uint32_t menu_entry(const char title[], const char options[], uint32_t *value);
+  uint32_t enumerate_entry(const char title[], const char options[], uint32_t *value);
   uint32_t bit_entry(const char title[], const char options[], uint8_t bit_position, uint32_t *value);
   int16_t number_entry(const char title[], const char format[], int16_t min, int16_t max, int16_t multiple, uint32_t *value);
   bool frequency_entry();

--- a/ui.h
+++ b/ui.h
@@ -72,6 +72,8 @@ class ui
   const uint32_t step_sizes[10] = {10, 50, 100, 1000, 5000, 10000, 12500, 25000, 50000, 100000};
   const uint16_t timeout_lookup[8] = {0, 50, 100, 150, 300, 600, 1200, 2400};
 
+  static constexpr char modes[5][4]  = {" AM", "LSB", "USB", " FM", " CW"};
+
   // Encoder 
   void setup_encoder();
   int32_t get_encoder_change();


### PR DESCRIPTION
#37 

    reuse print_enum_option in string_entry and frequency_entry

    menu_entry and enumerate_entry work out the "max" value from the options list

    consolidated the modes labels to a single array (cw, am, lsb...)

    Consolidate display_print_line into display_print_str
    - it can now center multiline text all by its very self