### PR TITLE
Improving IO handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ if(PICO_BOARD STREQUAL "pico")
       fft_filter.cpp
       ui.cpp
       utils.cpp
+      debouncer.c
+      event.c
   )
   pico_generate_pio_header(picorx ${CMAKE_CURRENT_LIST_DIR}/nco.pio)
   pico_generate_pio_header(picorx ${CMAKE_CURRENT_LIST_DIR}/quadrature_encoder.pio)

--- a/debouncer.c
+++ b/debouncer.c
@@ -1,0 +1,56 @@
+#include "debouncer.h"
+
+#include <stdbool.h>
+
+#include "pico/stdlib.h"
+#include "pico/util/queue.h"
+
+#define DEBOUNCE_TIME_MS (20)
+#define DEBOUNCE_COUNT (DEBOUNCE_TIME_MS * DEBOUNCE_TICK_HZ / 1000UL)
+
+extern queue_t core0_evq;
+
+void debouncer_init(debouncer_t *deb)
+{
+    deb->count = 0;
+    gpio_init(deb->gpio_num);
+    gpio_set_dir(deb->gpio_num, GPIO_IN);
+    gpio_pull_up(deb->gpio_num);
+}
+
+int8_t debouncer_update(debouncer_t *deb)
+{
+    int8_t ret = -1;
+
+    if (gpio_get(deb->gpio_num))
+    {
+        if (deb->count < DEBOUNCE_COUNT)
+        {
+            deb->count++;
+            if (deb->count == DEBOUNCE_COUNT)
+            {
+                if (deb->ev_release.tag != ev_none)
+                {
+                    event_send(deb->ev_release);
+                }
+                ret = 0;
+            }
+        }
+    }
+    else
+    {
+        if (deb->count > 0)
+        {
+            deb->count--;
+            if (deb->count == 0)
+            {
+                if (deb->ev_press.tag != ev_none)
+                {
+                    event_send(deb->ev_press);
+                }
+                ret = 1;
+            }
+        }
+    }
+    return ret;
+}

--- a/debouncer.h
+++ b/debouncer.h
@@ -1,0 +1,30 @@
+#ifndef __DEBOUNCER_H__
+#define __DEBOUNCER_H__
+
+#include <stdio.h>
+
+#include "event.h"
+
+#define DEBOUNCE_TICK_HZ (200L)
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef struct
+    {
+        const event_t ev_press;
+        const event_t ev_release;
+        const uint gpio_num;
+        size_t count;
+    } debouncer_t;
+
+    void debouncer_init(debouncer_t *deb);
+    int8_t debouncer_update(debouncer_t *deb);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __DEBOUNCER_H__

--- a/event.c
+++ b/event.c
@@ -1,0 +1,37 @@
+#include "event.h"
+
+#include <stdio.h>
+#include "pico/stdlib.h"
+#include "pico/util/queue.h"
+
+// the UI code still has some large blocking delays, so give it some slack
+#define CORE0_EVQ_LEN (4)
+
+static queue_t core0_evq;
+
+void event_init(void)
+{
+    queue_init(&core0_evq, sizeof(event_t), CORE0_EVQ_LEN);
+}
+
+void event_send(event_t event)
+{
+    bool s = queue_try_add(&core0_evq, &event);
+    hard_assert(s);
+}
+
+event_t event_get(void)
+{
+    event_t event;
+    queue_remove_blocking(&core0_evq, &event);
+    return event;
+}
+
+void event_print(event_t const *const ev)
+{
+    if (ev->tag < ev_last)
+    {
+        uint32_t _time_us = time_us_32();
+        printf("%ld: Event: %s\n", _time_us, event_to_str[ev->tag]);
+    }
+}

--- a/event.h
+++ b/event.h
@@ -1,0 +1,50 @@
+#ifndef __EVENT_H__
+#define __EVENT_H__
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef enum
+    {
+        ev_none = 0,
+        ev_tick,
+        ev_button_menu_press,
+        ev_button_menu_release,
+        ev_button_back_press,
+        ev_button_back_release,
+        ev_button_push_press,
+        ev_button_push_release,
+        ev_last,
+    } event_e;
+
+    typedef struct
+    {
+        event_e tag;
+    } event_t;
+
+    static const char *const event_to_str[] = {
+        "ev_none",
+        "ev_tick",
+        "ev_button_menu_press",
+        "ev_button_menu_release",
+        "ev_button_back_press",
+        "ev_button_back_release",
+        "ev_button_push_press",
+        "ev_button_push_release",
+    };
+
+    void event_init(void);
+    void event_send(event_t event);
+    event_t event_get(void);
+    void event_print(event_t const *const ev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __EVENT_H__

--- a/picorx.cpp
+++ b/picorx.cpp
@@ -21,6 +21,7 @@ const uint32_t ev_ui_evset = (1UL << ev_tick) |
                              (1UL << ev_button_menu_press) |
                              (1UL << ev_button_menu_release) |
                              (1UL << ev_button_back_press) |
+                             (1UL << ev_button_back_release) |
                              (1UL << ev_button_push_press);
 
 static debouncer_t button_menu_deb = {

--- a/picorx.cpp
+++ b/picorx.cpp
@@ -1,9 +1,13 @@
 #include "pico/stdlib.h"
 #include <stdio.h>
+
 #include "pico/multicore.h"
 #include "pico/time.h"
+
 #include "rx.h"
 #include "ui.h"
+#include "event.h"
+#include "debouncer.h"
 
 #define UI_REFRESH_HZ (10UL)
 #define UI_REFRESH_US (1000000UL / UI_REFRESH_HZ)
@@ -13,26 +17,78 @@ static rx_status status;
 static rx receiver(settings_to_apply, status);
 static ui user_interface(settings_to_apply, status,  receiver);
 
+const uint32_t ev_ui_evset = (1UL << ev_tick) |
+                             (1UL << ev_button_menu_press) |
+                             (1UL << ev_button_menu_release) |
+                             (1UL << ev_button_back_press) |
+                             (1UL << ev_button_push_press);
+
+static debouncer_t button_menu_deb = {
+    .ev_press = {.tag = ev_button_menu_press},
+    .ev_release = {.tag = ev_button_menu_release},
+    .gpio_num = PIN_MENU,
+};
+
+static debouncer_t button_back_deb = {
+    .ev_press = {.tag = ev_button_back_press},
+    .ev_release = {.tag = ev_button_back_release},
+    .gpio_num = PIN_BACK,
+};
+
+static debouncer_t button_push_deb = {
+    .ev_press = {.tag = ev_button_push_press},
+    .ev_release = {.tag = ev_button_push_release},
+    .gpio_num = PIN_ENCODER_PUSH,
+};
+
 void core1_main()
 {
     multicore_lockout_victim_init();
     receiver.run();
 }
 
+static bool io_callback(repeating_timer_t *rt)
+{
+    static uint8_t tick_div = 0;
+
+    debouncer_update(&button_menu_deb);
+    debouncer_update(&button_back_deb);
+    debouncer_update(&button_push_deb);
+
+    if (++tick_div == (DEBOUNCE_TICK_HZ / UI_REFRESH_HZ))
+    {
+      tick_div = 0;
+      event_t ev = {.tag = ev_tick};
+      event_send(ev);
+    }
+
+    return true; // keep repeating
+}
+
 int main() 
 {
+  repeating_timer_t io_timer;
+
   stdio_init_all();
-  multicore_launch_core1(core1_main);    
+  multicore_launch_core1(core1_main);
+
+  event_init();
+  debouncer_init(&button_menu_deb);
+  debouncer_init(&button_back_deb);
+  debouncer_init(&button_push_deb);  
 
   //sleep_us(5000000);
   user_interface.autorestore();
 
+  bool ret = add_repeating_timer_us(-1000000 / DEBOUNCE_TICK_HZ, io_callback, NULL, &io_timer);
+  hard_assert(ret);
+
   while(1)
   {
-    uint32_t _time_us = time_us_32();
-    user_interface.do_ui();
-    _time_us = time_us_32() - _time_us;
-    if (_time_us < UI_REFRESH_US)
-      sleep_us(UI_REFRESH_US - _time_us);
+    event_t event = event_get();
+    if((1UL << event.tag) & (ev_ui_evset))
+    {
+      user_interface.do_ui(event);
+    }
   }
 }

--- a/ui.cpp
+++ b/ui.cpp
@@ -1257,6 +1257,15 @@ void ui::do_ui(event_t event)
         {
           button_state = down;
           timeout = 100;
+        } else if (event.tag == ev_button_back_press)
+        {
+          button_state = slow_mode;
+        }
+        break;
+      case slow_mode:
+        if (event.tag == ev_button_back_release)
+        {
+          button_state = idle;
         }
         break;
       case down:
@@ -1273,6 +1282,19 @@ void ui::do_ui(event_t event)
         if(event.tag == ev_button_menu_release)
         {
           button_state = idle;
+        } else if(event.tag == ev_button_back_press)
+        {
+          button_state = very_fast_mode;
+        }
+        break;
+      case very_fast_mode:
+        if (event.tag == ev_button_back_release)
+        {
+          button_state = fast_mode;
+        }
+        else if (event.tag == ev_button_menu_release)
+        {
+          button_state = slow_mode;
         }
         break;
       case menu:
@@ -1287,22 +1309,27 @@ void ui::do_ui(event_t event)
       frequency_autosave_pending = false;
       frequency_autosave_timer = 10u;
 
-      if(button_state == fast_mode && (event.tag == ev_button_back_press))
+      switch (button_state)
       {
-        //very fast if both buttons pressed
-        settings[idx_frequency] += encoder_change * step_sizes[settings[idx_step]] * 100;
-      }
-      else if(button_state == fast_mode)
-      {
-        //fast if menu button held
+      case fast_mode:
+        // fast if menu button held
         settings[idx_frequency] += encoder_change * step_sizes[settings[idx_step]] * 10;
-      }
-      else if(event.tag == ev_button_back_press)
-      {
-        //slow if cancel button held
+        break;
+
+      case very_fast_mode:
+        // very fast if both buttons pressed
+        settings[idx_frequency] += encoder_change * step_sizes[settings[idx_step]] * 100;
+        break;
+
+      case slow_mode:
+        // slow if cancel button held
         settings[idx_frequency] += encoder_change * (step_sizes[settings[idx_step]] / 10);
+        break;
+
+      default:
+      settings[idx_frequency] += encoder_change * step_sizes[settings[idx_step]];
+        break;
       }
-      else settings[idx_frequency] += encoder_change * step_sizes[settings[idx_step]];
 
       if (settings[idx_frequency] > settings[idx_max_frequency])
           settings[idx_frequency] = settings[idx_min_frequency];

--- a/ui.cpp
+++ b/ui.cpp
@@ -2,7 +2,11 @@
 #include "pico/multicore.h"
 #include "ui.h"
 #include <hardware/flash.h>
+#include "pico/util/queue.h"
 
+static const uint32_t ev_display_tmout_evset = (1UL << ev_button_menu_press) |
+                                               (1UL << ev_button_back_press) |
+                                               (1UL << ev_button_push_press);
 
 ////////////////////////////////////////////////////////////////////////////////
 // Encoder 
@@ -38,37 +42,6 @@ int32_t ui::encoder_control(int32_t *value, int32_t min, int32_t max)
 	if(*value > max) *value = min;
 	if(*value < min) *value = max;
 	return position_change;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// Buttons 
-////////////////////////////////////////////////////////////////////////////////
-
-void ui::setup_buttons()
-{
-  gpio_init(PIN_MENU);
-  gpio_set_dir(PIN_MENU, GPIO_IN);
-  gpio_pull_up(PIN_MENU);
-  gpio_init(PIN_BACK);
-  gpio_set_dir(PIN_BACK, GPIO_IN);
-  gpio_pull_up(PIN_BACK);
-  gpio_init(PIN_ENCODER_PUSH);
-  gpio_set_dir(PIN_ENCODER_PUSH, GPIO_IN);
-  gpio_pull_up(PIN_ENCODER_PUSH);
-}
-
-bool ui::get_button(uint8_t button){
-	if(!gpio_get(button)){
-		while(!gpio_get(button)){}
-		WAIT_10MS
-		return 1;
-	}
-	WAIT_10MS
-	return 0;
-}
-
-bool ui::check_button(unsigned button){
-	return !gpio_get(button);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -363,18 +336,17 @@ uint32_t ui::menu_entry(const char title[], const char options[], uint32_t *valu
       display_show();
     }
 
+    event_t ev = event_get();
     //select menu item
-    if(get_button(PIN_MENU)){
+    if(ev.tag == ev_button_menu_press){
       *value = select;
       return 1;
     }
 
     //cancel
-    if(get_button(PIN_BACK)){
+    if(ev.tag == ev_button_back_press){
       return 0;
     }
-
-    WAIT_100MS
   }
 }
 
@@ -404,18 +376,17 @@ uint32_t ui::enumerate_entry(const char title[], const char options[], uint32_t 
       display_show();
     }
 
+    event_t ev = event_get();
     //select menu item
-    if(get_button(PIN_MENU)){
+    if(ev.tag == ev_button_menu_press){
       *value = select;
       return 1;
     }
 
     //cancel
-    if(get_button(PIN_BACK)){
+    if(ev.tag == ev_button_back_press){
       return 0;
     }
-
-    WAIT_100MS
   }
 }
 
@@ -437,18 +408,18 @@ int16_t ui::number_entry(const char title[], const char format[], int16_t min, i
       display_show();
     }
 
+    event_t ev = event_get();
+
     //select menu item
-    if(get_button(PIN_MENU)){
+    if(ev.tag == ev_button_menu_press){
       *value = select*multiple;
       return 1;
     }
 
     //cancel
-    if(get_button(PIN_BACK)){
+    if(ev.tag == ev_button_back_press){
       return 0;
     }
-
-    WAIT_100MS
   }
 }
 
@@ -762,8 +733,10 @@ bool ui::store()
       }
     }
 
+    event_t ev = event_get();
+
     //select menu item
-    if(get_button(PIN_MENU)){
+    if(ev.tag == ev_button_menu_press){
 
       //work out which flash sector the channel sits in.
       const uint32_t num_channels_per_sector = FLASH_SECTOR_SIZE/(sizeof(int)*chan_size);
@@ -830,11 +803,9 @@ bool ui::store()
     }
 
     //cancel
-    if(get_button(PIN_BACK)){
+    if(ev.tag == ev_button_back_press){
       return false;
     }
-
-    WAIT_100MS
   }
 }
 
@@ -956,18 +927,20 @@ bool ui::recall()
       }
     }
 
-    if(get_button(PIN_ENCODER_PUSH)){
+    event_t ev = event_get();
+
+    if(ev.tag == ev_button_push_press){
       last_select=min;
       return 1;
     }
 
-    if(get_button(PIN_MENU)){
+    if(ev.tag == ev_button_menu_press){
       last_select=select;
       return 1;
     }
 
     //cancel
-    if(get_button(PIN_BACK)){
+    if(ev.tag == ev_button_back_press){
       //put things back how they were to start with
       for(uint8_t i=0; i<settings_to_store; i++){
         settings[i] = stored_settings[i];
@@ -975,8 +948,6 @@ bool ui::recall()
       apply_settings(false);
       return 0;
     }
-
-    WAIT_100MS
   }
 }
 
@@ -1041,8 +1012,10 @@ bool ui::string_entry(char string[]){
       display_show();
     }
 
+    event_t ev = event_get();
+
     //select menu item
-    if(get_button(PIN_MENU))
+    if(ev.tag == ev_button_menu_press)
     {
       draw_once = true;
 	    edit_mode = !edit_mode;
@@ -1054,7 +1027,7 @@ bool ui::string_entry(char string[]){
 	  }
 
     //cancel
-    if(get_button(PIN_BACK))
+    if(ev.tag == ev_button_back_press)
     {
       return false;
     }
@@ -1119,8 +1092,10 @@ bool ui::frequency_entry(){
       display_show();
     }
 
+    event_t ev = event_get();
+
     //select menu item
-    if(get_button(PIN_MENU))
+    if(ev.tag == ev_button_menu_press)
     {
       draw_once = true;
 	    edit_mode = !edit_mode;
@@ -1149,14 +1124,14 @@ bool ui::frequency_entry(){
 	  }
 
     //cancel
-    if(get_button(PIN_BACK))
+    if(ev.tag == ev_button_back_press)
     {
       return false;
     }
   }
 }
 
-bool ui::display_timeout(bool encoder_change)
+bool ui::display_timeout(bool encoder_change, event_t event)
 {
     uint8_t display_timeout_setting = (settings[idx_hw_setup] & mask_display_timeout) >> flag_display_timeout;
     uint16_t display_timeout = timeout_lookup[display_timeout_setting];
@@ -1166,12 +1141,15 @@ bool ui::display_timeout(bool encoder_change)
 
     //A button press causes timer to be reset to max value
     //and re-enables the display if it was previously off
-    if(encoder_change || check_button(PIN_MENU) || check_button(PIN_BACK) || check_button(PIN_ENCODER_PUSH))
+    if(encoder_change || ((1UL << event.tag) & (ev_display_tmout_evset)))
     {
       if(!display_timer)
       {
         ssd1306_poweron(&disp);
-        while(check_button(PIN_MENU) || check_button(PIN_BACK) || check_button(PIN_ENCODER_PUSH)) WAIT_100MS;
+        do
+        {
+          event = event_get();
+        } while (((1UL << event.tag) & (ev_display_tmout_evset)));
         display_timer = display_timeout;
         return false;
       }
@@ -1262,20 +1240,20 @@ bool ui::configuration_menu()
 ////////////////////////////////////////////////////////////////////////////////
 // This is the main UI loop. Should get called about 10 times/second
 ////////////////////////////////////////////////////////////////////////////////
-void ui::do_ui(void)
+void ui::do_ui(event_t event)
 {
     static bool rx_settings_changed = true;
     bool autosave_settings = false;
     uint32_t encoder_change = get_encoder_change();
 
     //automatically switch off display after a period of inactivity
-    if(!display_timeout(encoder_change)) return;
+    if(!display_timeout(encoder_change, event)) return;
 
     //update frequency if encoder changes
     switch(button_state)
     {
       case idle:
-        if(check_button(PIN_MENU))
+        if(event.tag == ev_button_menu_press)
         {
           button_state = down;
           timeout = 100;
@@ -1286,13 +1264,13 @@ void ui::do_ui(void)
         {
           button_state = fast_mode;
         }
-        else if(!check_button(PIN_MENU))
+        else if(event.tag == ev_button_menu_release)
         {
           button_state = menu;
         }
         break;
       case fast_mode:
-        if(!check_button(PIN_MENU))
+        if(event.tag == ev_button_menu_release)
         {
           button_state = idle;
         }
@@ -1309,7 +1287,7 @@ void ui::do_ui(void)
       frequency_autosave_pending = false;
       frequency_autosave_timer = 10u;
 
-      if(button_state == fast_mode && check_button(PIN_BACK))
+      if(button_state == fast_mode && (event.tag == ev_button_back_press))
       {
         //very fast if both buttons pressed
         settings[idx_frequency] += encoder_change * step_sizes[settings[idx_step]] * 100;
@@ -1319,7 +1297,7 @@ void ui::do_ui(void)
         //fast if menu button held
         settings[idx_frequency] += encoder_change * step_sizes[settings[idx_step]] * 10;
       }
-      else if(check_button(PIN_BACK))
+      else if(event.tag == ev_button_back_press)
       {
         //slow if cancel button held
         settings[idx_frequency] += encoder_change * (step_sizes[settings[idx_step]] / 10);
@@ -1409,7 +1387,7 @@ void ui::do_ui(void)
       }
       autosave_settings = rx_settings_changed;
     }
-    else if(get_button(PIN_ENCODER_PUSH))
+    else if(event.tag == ev_button_push_press)
     {
       rx_settings_changed = recall();
       autosave_settings = rx_settings_changed;
@@ -1446,7 +1424,6 @@ ui::ui(rx_settings & settings_to_apply, rx_status & status, rx &receiver) : sett
 {
   setup_display();
   setup_encoder();
-  setup_buttons();
 
   button_state = idle;
 }

--- a/ui.h
+++ b/ui.h
@@ -11,6 +11,7 @@
 #include "rx.h"
 #include "memory.h"
 #include "autosave_memory.h"
+#include "event.h"
 
 const uint8_t PIN_AB = 20;
 const uint8_t PIN_B  = 21;
@@ -50,7 +51,6 @@ const uint8_t PIN_DISPLAY_SCL = 19;
 // define wait macros
 #define WAIT_10MS sleep_us(10000);
 #define WAIT_100MS sleep_us(100000);
-#define WAIT_500MS sleep_us(500000);;
 
 enum e_button_state {idle, down, fast_mode, menu};
 
@@ -82,10 +82,7 @@ class ui
   const uint32_t sm = 0;
   const PIO pio = pio1;
 
-  // Buttons 
-  void setup_buttons();
-  bool get_button(uint8_t button);
-  bool check_button(unsigned button);
+  // Buttons
   e_button_state button_state;
   uint8_t timeout;
 
@@ -130,7 +127,7 @@ class ui
   bool upload_memory();
   void autosave();
   void apply_settings(bool suspend);
-  bool display_timeout(bool encoder_change);
+  bool display_timeout(bool encoder_change, event_t event);
 
   uint32_t regmode = 1;
 
@@ -141,7 +138,7 @@ class ui
   public:
 
   void autorestore();
-  void do_ui(void);
+  void do_ui(event_t event);
   ui(rx_settings & settings_to_apply, rx_status & status, rx &receiver);
 
 };

--- a/ui.h
+++ b/ui.h
@@ -52,7 +52,7 @@ const uint8_t PIN_DISPLAY_SCL = 19;
 #define WAIT_10MS sleep_us(10000);
 #define WAIT_100MS sleep_us(100000);
 
-enum e_button_state {idle, down, fast_mode, menu};
+enum e_button_state {idle, down, slow_mode, fast_mode, very_fast_mode, menu};
 
 // font styles styles as bits to be ORed
 #define style_normal      0


### PR DESCRIPTION
This PR is a first step towards more reactive design. In current design, due to blocking waits scattered throughout `ui.cpp`, there was noticeable jitter and button presses were missed fairly often.
Next steps:
 - move encoder handling to the same timer as other switches
 - eliminate `event_get` calls, as ideally there should be only one, top-level call to this function and the events should be propagated from this point. Requires significant `ui.cpp` changes (introducing explicit `ui_state` variable, eliminating all infinite while loops, moving to a more data-driven menu design).