### PR TITLE
ssd1306_scroll_screen(&disp, uint x, uint y );

### DIFF
--- a/ssd1306.h
+++ b/ssd1306.h
@@ -75,6 +75,9 @@ typedef struct {
 	uint8_t disp_col_offset; /**< 0 for ssd1306, 2 for sh1106 */
 } ssd1306_t;
 
+ void ssd1306_set_start_line(ssd1306_t *p, uint8_t val);
+ void ssd1306_scroll_screen(ssd1306_t *p, int16_t x, int16_t y);
+
 /**
 *	@brief initialize display
 *

--- a/ui.cpp
+++ b/ui.cpp
@@ -1,5 +1,6 @@
 #include <string.h>
 #include <float.h>
+#include <math.h>
 
 #include "pico/multicore.h"
 #include "ui.h"
@@ -405,16 +406,17 @@ void ui::draw_h_tick_marks(uint16_t startY)
 ////////////////////////////////////////////////////////////////////////////////
 void ui::update_display5(rx_status & status, rx & receiver)
 {
-  static int start_line = 0;
-  if (start_line == 0) {
-    display_clear();
-    ssd1306_bmp_show_image(&disp, crystal, 1086);
-  } else {
-     ssd1306_scroll_screen(&disp, -1, +4);
+  static int degrees = 0;
+  static int xm, ym;
+  if (degrees == 0) {
+    xm = rand()%10+1;
+    ym = rand()%10;
   }
+  display_clear();
+  ssd1306_bmp_show_image(&disp, crystal, sizeof(crystal));
+  ssd1306_scroll_screen(&disp, 40*cos(xm*M_PI*degrees/180), 20*sin(ym*M_PI*degrees/180));
   display_show();
-//  ssd1306_set_start_line(&disp, 0x3f-start_line);
-  if (++start_line > 0x3f) start_line=0;
+  if ((degrees+=3) >=360) degrees = 0;
 }
 
 

--- a/ui.cpp
+++ b/ui.cpp
@@ -405,9 +405,16 @@ void ui::draw_h_tick_marks(uint16_t startY)
 ////////////////////////////////////////////////////////////////////////////////
 void ui::update_display5(rx_status & status, rx & receiver)
 {
-  display_clear();
-  ssd1306_bmp_show_image(&disp, crystal, 1086);
+  static int start_line = 0;
+  if (start_line == 0) {
+    display_clear();
+    ssd1306_bmp_show_image(&disp, crystal, 1086);
+  } else {
+     ssd1306_scroll_screen(&disp, -1, +4);
+  }
   display_show();
+//  ssd1306_set_start_line(&disp, 0x3f-start_line);
+  if (++start_line > 0x3f) start_line=0;
 }
 
 


### PR DESCRIPTION
Shift the display memory horizontally and/or vertically. Supports positive and vertical.

The displaybuffer is edited in place - zeros get shifted in, it does not wrap the data.

update_display5 dances around with a lissajous pattern as a test. but it looks pretty so ive left it in :) (for now?)

