### PR TITLE
Recall shows signal strength & tidying (take 2)

### DIFF
--- a/ui.cpp
+++ b/ui.cpp
@@ -1181,37 +1181,40 @@ bool ui::memory_recall()
       display_clear();
       display_print_str("Recall");
       display_print_num(" %03i ", select, 1, style_centered);
-      display_print_str(modes[radio_memory[select][idx_mode]],1,style_right);
+
+      const char* mode_ptr = modes[radio_memory[select][idx_mode]];
+      display_set_xy(128-6*strlen(mode_ptr)-8, display_get_y());
+      display_print_str(mode_ptr,1);
 
       display_print_str("\n", 1);
       if (12*strlen(name) > 128) {
         display_add_xy(0,4);
-        display_print_str(name,1,style_nowrap|style_centered);
+        display_print_str(name,1,style_nowrap);
       } else {
-        display_print_str(name,2,style_nowrap|style_centered);
+        display_print_str(name,2,style_nowrap);
       }
 
       //draw frequency
       display_set_xy(0,27);
-      display_print_freq('.', radio_memory[select][idx_frequency], 2, style_centered);
+      display_print_freq('.', radio_memory[select][idx_frequency], 2);
       display_print_str("\n",2);
 
-//      ssd1306_fill_rectangle(&disp, 0, display_get_y()-3, power_s*127/12, 2, 1);
-
-      display_print_str("from: ", 1);
+      display_print_str("from:  ", 1);
       display_print_freq(',', radio_memory[select][idx_min_frequency], 1);
       display_print_str(" Hz\n",1);
 
-//      ssd1306_draw_line(&disp, 0, display_get_y()-2, power_s*127/12, display_get_y()-2, 1);
-
-      display_print_str("  To: ", 1);
+      display_print_str("  To:  ", 1);
       display_print_freq(',', radio_memory[select][idx_max_frequency], 1);
       display_print_str(" Hz\n",1);
 
-//      ssd1306_draw_line(&disp, 0, 63, power_s*127/12, 63, 1);
-      ssd1306_fill_rectangle(&disp, 0, 62, power_s*127/12, 2, 1);
+      int bar_len = power_s*62/12;
+// framed
+//      ssd1306_draw_rectangle(&disp, 124, 0, 3, 63, 1);
+//      ssd1306_fill_rectangle(&disp, 125, 63-bar_len, 2, bar_len+1, 1);
 
-      ssd1306_fill_rectangle(&disp, 0, 0, power_s*127/12, 8, 2);
+//solid
+      ssd1306_fill_rectangle(&disp, 124, 63-bar_len, 3, bar_len+1, 1);
+
       display_show();
     }
 

--- a/ui.h
+++ b/ui.h
@@ -127,11 +127,11 @@ class ui
   // Status                  
   float calculate_signal_strength(rx_status &status);
 
-  void update_display(rx_status & status, rx & receiver);
-  void update_display2(rx_status & status, rx & receiver);
-  void update_display3(rx_status & status, rx & receiver);
-  void update_display4(rx_status & status, rx & receiver);
-  void update_display5(rx_status & status, rx & receiver);
+  void renderpage_original(bool view_changed, rx_status & status, rx & receiver);
+  void renderpage_bigspectrum(bool view_changed, rx_status & status, rx & receiver);
+  void renderpage_waterfall(bool view_changed, rx_status & status, rx & receiver);
+  void renderpage_bigtext(bool view_changed, rx_status & status, rx & receiver);
+  void renderpage_fun(bool view_changed, rx_status & status, rx & receiver);
   #define NUM_VIEWS 5
 
   int dBm_to_S(float power_dBm);
@@ -152,8 +152,8 @@ class ui
   bool frequency_entry(const char title[], uint32_t which_setting);
   int string_entry(char string[]);
   bool configuration_menu();
-  bool recall();
-  bool store();
+  bool memory_recall();
+  bool memory_store();
   bool upload_memory();
   void autosave();
   void apply_settings(bool suspend);

--- a/ui.h
+++ b/ui.h
@@ -134,6 +134,7 @@ class ui
   void update_display5(rx_status & status, rx & receiver);
   #define NUM_VIEWS 5
 
+  int dBm_to_S(float power_dBm);
   void log_spectrum(float *min, float *max);
   void draw_h_tick_marks(uint16_t startY);
   void draw_spectrum(rx & receiver, uint16_t startY);

--- a/ui.h
+++ b/ui.h
@@ -137,8 +137,10 @@ class ui
   int dBm_to_S(float power_dBm);
   void log_spectrum(float *min, float *max);
   void draw_h_tick_marks(uint16_t startY);
-  void draw_spectrum(rx & receiver, uint16_t startY);
-  void draw_waterfall(rx & receiver);
+  void draw_spectrum(uint16_t startY, rx & receiver);
+  void draw_waterfall(uint16_t startY, rx & receiver);
+  void draw_slim_status(uint16_t y, rx_status & status, rx & receiver);
+
   bool frequency_autosave_pending = false;
   uint8_t frequency_autosave_timer = 10u;
 


### PR DESCRIPTION
Added signal strength to Recall page

Waterfall uses display scrolling and just paints the new row.

tidying:
factored out int ui::dBm_to_S(float power_dBm);
factored out draw_slim_status(uint16_t y, rx_status & status, rx & receiver);

renderpage_* now know if they've just been switched to (so the can reinit if required)

s/recall/memory_recall/
s/store/memory_store/
s/update_display/renderpage_original/
s/update_display2/renderpage_bigspectrum/
s/update_display3/renderpage_waterfall/
s/update_display4/renderpage_bigtext/
s/update_display5/renderpage_fun/
