### PR TITLE
Scanner now pauses when a signal is found

### DIFF
--- a/rx.cpp
+++ b/rx.cpp
@@ -124,6 +124,7 @@ void rx::update_status()
      status.busy_time = busy_time;
      status.battery = battery;
      status.temp = temp;
+     status.squelch_state = rx_dsp_inst.get_squelch_state();
      sem_release(&settings_semaphore);
    }
 }

--- a/rx.h
+++ b/rx.h
@@ -39,6 +39,7 @@ struct rx_status
   uint32_t busy_time;
   uint16_t temp;
   uint16_t battery;
+  bool squelch_state;
 };
 
 class rx

--- a/rx_dsp.cpp
+++ b/rx_dsp.cpp
@@ -121,7 +121,12 @@ uint16_t __not_in_flash_func(rx_dsp :: process_block)(uint16_t samples[], int16_
       audio = ((int32_t)audio * gain_numerator) >> 8;
 
       //squelch
-      if(signal_amplitude < squelch_threshold) audio = 0;
+      if(signal_amplitude < squelch_threshold) {
+        audio = 0;
+        squelch_state = false;
+      } else {
+        squelch_state = true;
+      }
 
       //convert to unsigned value in range 0 to 500 to output to PWM
       audio += INT16_MAX;
@@ -535,6 +540,11 @@ void rx_dsp :: set_squelch(uint8_t val)
 void rx_dsp :: set_pwm_max(uint32_t pwm_max)
 {
   pwm_scale = 1+((INT16_MAX * 2)/pwm_max);
+}
+
+bool rx_dsp :: get_squelch_state()
+{
+  return squelch_state;
 }
 
 int16_t rx_dsp :: get_signal_strength_dBm()

--- a/rx_dsp.h
+++ b/rx_dsp.h
@@ -24,6 +24,7 @@ class rx_dsp
   void set_pwm_max(uint32_t pwm_max);
   void set_auto_notch(bool enable_auto_notch);
   int16_t get_signal_strength_dBm();
+  bool get_squelch_state();   // false is muted
   void get_spectrum(float spectrum[]);
 
 
@@ -89,6 +90,7 @@ class rx_dsp
   //squelch
   int16_t squelch_threshold=0;
   int16_t s9_threshold=0;
+  bool squelch_state = false;
 
   //used in AGC
   uint8_t attack_factor;

--- a/ui.cpp
+++ b/ui.cpp
@@ -1635,9 +1635,16 @@ bool ui::frequency_scan()
       display_print_str(" Hz\n",1);
 
       //draw scanning speed
-      display_set_xy(0,48);
-      display_print_str("Speed",2);
-      display_print_speed(91, display_get_y(), 2, scan_speed);
+      if (can_scan) {
+        display_set_xy(0,48);
+        display_print_str("Speed",2);
+        display_print_speed(91, display_get_y(), 2, scan_speed);
+      } else {
+        display_set_xy(0,48);
+        display_print_str("Listen",2);
+        display_set_xy(91-6,48);
+        display_print_char(CHAR_SPEAKER, 2);
+      }
 
       // draw vertical signal strength
       draw_vertical_dBm( 124, power_dBm);

--- a/ui.cpp
+++ b/ui.cpp
@@ -367,10 +367,12 @@ void ui::draw_slim_status(uint16_t y, rx_status & status, rx & receiver)
 }
 
 // draw vertical signal strength
-void ui::draw_vertical_dBm(uint16_t x, float power_dBm) {
+void ui::draw_vertical_dBm(uint16_t x, float power_dBm, float squelch) {
       int bar_len = dBm_to_63px(power_dBm);
+      int sq = dBm_to_63px(squelch);
       ssd1306_fill_rectangle(&disp, x, 0, 3, 63, 0);
       ssd1306_fill_rectangle(&disp, x, 63 - bar_len, 3, bar_len + 1, 1);
+      ssd1306_draw_line(&disp, x, 63-sq, x+3, 63-sq, 2);
 }
 
 int ui::dBm_to_S(float power_dBm) {
@@ -379,6 +381,16 @@ int ui::dBm_to_S(float power_dBm) {
   if(power_s < 0) power_s = 0;
   if(power_s > 12) power_s = 12;
   return (power_s);
+}
+
+float ui::S_to_dBm(int S) {
+  float dBm = 0;
+  if (S<=9) {
+    dBm = S0 + 6.0f * S;
+  } else {
+    dBm = S9_10 + (S-10) * 10.f;
+  }
+  return (dBm);
 }
 
 int32_t ui::dBm_to_63px(float power_dBm) {
@@ -1345,7 +1357,7 @@ bool ui::memory_recall()
     if (power_change)
     {
       // draw vertical signal strength
-      draw_vertical_dBm( 124, power_dBm);
+      draw_vertical_dBm( 124, power_dBm, S_to_dBm(settings[idx_squelch]));
     }
 
     if ((pos_change != 0) || draw_once || power_change)
@@ -1501,7 +1513,7 @@ bool ui::memory_scan()
       }
 
       // draw vertical signal strength
-      draw_vertical_dBm( 124, power_dBm);
+      draw_vertical_dBm( 124, power_dBm, S_to_dBm(settings[idx_squelch]));
 
       display_show();
     }
@@ -1679,7 +1691,8 @@ bool ui::frequency_scan()
       }
 
       // draw vertical signal strength
-      draw_vertical_dBm( 124, power_dBm);
+      draw_vertical_dBm( 124, power_dBm, S_to_dBm(settings[idx_squelch]));
+//      draw_vertical_dBm( 124, power_dBm);
 
       display_show();
     }

--- a/ui.cpp
+++ b/ui.cpp
@@ -366,12 +366,27 @@ void ui::draw_slim_status(uint16_t y, rx_status & status, rx & receiver)
   display_print_num("% 4ddBm", (int)power_dBm, 1, style_right);
 }
 
+// draw vertical signal strength
+void ui::draw_vertical_dBm(uint16_t x, float power_dBm) {
+      int bar_len = dBm_to_63px(power_dBm);
+      ssd1306_fill_rectangle(&disp, x, 0, 3, 63, 0);
+      ssd1306_fill_rectangle(&disp, x, 63 - bar_len, 3, bar_len + 1, 1);
+}
+
 int ui::dBm_to_S(float power_dBm) {
   int power_s = floorf((power_dBm-S0)/6.0f);
   if(power_dBm >= S9) power_s = floorf((power_dBm-S9)/10.0f)+9;
   if(power_s < 0) power_s = 0;
   if(power_s > 12) power_s = 12;
   return (power_s);
+}
+
+int32_t ui::dBm_to_63px(float power_dBm) {
+        int32_t power = floorf((power_dBm-S0));
+        power = power * 63 / (S9_10 + 20 - S0);
+        if (power<0) power=0;
+        if (power>63) power=63;
+        return (power);
 }
 
 void ui::log_spectrum(float *min, float *max)
@@ -1250,7 +1265,6 @@ bool ui::memory_recall()
   int32_t pos_change = 0;
   float power_dBm;
   float last_power_dBm = FLT_MAX;
-  int8_t power_s = 0;
 
   //remember where we were incase we need to cancel
   uint32_t stored_settings[settings_to_store];
@@ -1265,7 +1279,6 @@ bool ui::memory_recall()
     receiver.release();
     if (power_dBm != last_power_dBm) {
       //signal strength as an int 0..12
-      power_s = dBm_to_S(power_dBm);
       power_change = true;
       last_power_dBm = power_dBm;
     }
@@ -1331,14 +1344,8 @@ bool ui::memory_recall()
 
     if (power_change)
     {
-      int bar_len = power_s * 62 / 12;
-      // framed
-      // ssd1306_draw_rectangle(&disp, 124, 0, 3, 63, 1);
-      // ssd1306_fill_rectangle(&disp, 125, 63-bar_len, 2, bar_len+1, 1);
-
-      // solid
-      ssd1306_fill_rectangle(&disp, 124, 0, 3, 63, 0);
-      ssd1306_fill_rectangle(&disp, 124, 63 - bar_len, 3, bar_len + 1, 1);
+      // draw vertical signal strength
+      draw_vertical_dBm( 124, power_dBm);
     }
 
     if ((pos_change != 0) || draw_once || power_change)
@@ -1391,7 +1398,6 @@ bool ui::memory_scan()
   int32_t pos_change = 0;
   float power_dBm;
   float last_power_dBm = FLT_MAX;
-  int8_t power_s = 0;
 
   //remember where we were incase we need to cancel
   uint32_t stored_settings[settings_to_store];
@@ -1406,7 +1412,6 @@ bool ui::memory_scan()
     receiver.release();
     if (power_dBm != last_power_dBm) {
       //signal strength as an int 0..12
-      power_s = dBm_to_S(power_dBm);
       draw_once = true;
       last_power_dBm = power_dBm;
     }
@@ -1476,8 +1481,7 @@ bool ui::memory_scan()
       display_print_speed(91, display_get_y(), 2, scan_speed);
 
       // draw vertical signal strength
-      int bar_len = power_s*62/12;
-      ssd1306_fill_rectangle(&disp, 124, 63-bar_len, 3, bar_len+1, 1);
+      draw_vertical_dBm( 124, power_dBm);
 
       display_show();
     }
@@ -1551,7 +1555,6 @@ bool ui::frequency_scan()
   int32_t pos_change = 0;
   float power_dBm;
   float last_power_dBm = FLT_MAX;
-  int8_t power_s = 0;
 
   //remember where we were incase we need to cancel
   uint32_t stored_settings[settings_to_store];
@@ -1568,7 +1571,6 @@ bool ui::frequency_scan()
     receiver.release();
     if (power_dBm != last_power_dBm) {
       //signal strength as an int 0..12
-      power_s = dBm_to_S(power_dBm);
       draw_once = true;
       last_power_dBm = power_dBm;
     }
@@ -1629,8 +1631,7 @@ bool ui::frequency_scan()
       display_print_speed(91, display_get_y(), 2, scan_speed);
 
       // draw vertical signal strength
-      int bar_len = power_s*62/12;
-      ssd1306_fill_rectangle(&disp, 124, 63-bar_len, 3, bar_len+1, 1);
+      draw_vertical_dBm( 124, power_dBm);
 
       display_show();
     }

--- a/ui.h
+++ b/ui.h
@@ -144,13 +144,14 @@ class ui
   #define NUM_VIEWS 6
 
   int dBm_to_S(float power_dBm);
+  float S_to_dBm(int S);
   int32_t dBm_to_63px(float power_dBm);
   void log_spectrum(float *min, float *max);
   void draw_h_tick_marks(uint16_t startY);
   void draw_spectrum(uint16_t startY, rx & receiver);
   void draw_waterfall(uint16_t startY, rx & receiver);
   void draw_slim_status(uint16_t y, rx_status & status, rx & receiver);
-  void draw_vertical_dBm(uint16_t x, float power_dBm);
+  void draw_vertical_dBm(uint16_t x, float power_dBm, float squelch);
   void draw_analogmeter(    uint16_t startx, uint16_t starty, 
                               uint16_t width, int16_t height,
                               float  needle_pct, int numticks = 0,

--- a/ui.h
+++ b/ui.h
@@ -144,11 +144,13 @@ class ui
   #define NUM_VIEWS 6
 
   int dBm_to_S(float power_dBm);
+  int32_t dBm_to_63px(float power_dBm);
   void log_spectrum(float *min, float *max);
   void draw_h_tick_marks(uint16_t startY);
   void draw_spectrum(uint16_t startY, rx & receiver);
   void draw_waterfall(uint16_t startY, rx & receiver);
   void draw_slim_status(uint16_t y, rx_status & status, rx & receiver);
+  void draw_vertical_dBm(uint16_t x, float power_dBm);
   void draw_analogmeter(    uint16_t startx, uint16_t starty, 
                               uint16_t width, int16_t height,
                               float  needle_pct, int numticks = 0,

--- a/ui.h
+++ b/ui.h
@@ -173,6 +173,7 @@ class ui
   bool top_menu(rx_settings & settings_to_apply);
   bool configuration_menu();
   bool scanner_menu();
+  bool scanner_radio_menu();
   bool frequency_scan();
   bool memory_recall();
   bool memory_scan();


### PR DESCRIPTION
Scanning - memory and frequency:
- the scanners now pauses when a signal breaks the squelch threshold.
- Overlay a bar on the vertical S-meter to show the squelch level
- Updates display to show listen vs scanning
- move the rotary left or right to continue
- short press on "menu" -> launches scanner_radio_menu() with a subset of the main menu for quicker access 
- long press on menu -> select station and quit
- any press back -> quit and restore radio settings

TODO:
only resume scanning if no signal for > 'n' seconds

Behind the scenes:
- Expose squelch state so the scanner can use it
- factored out draw_vertical_dBm( 124, power_dBm);
- created dBm_to_63px(float power_dBm);
