### PR TITLE
Made the display draw more pre-emptive

### DIFF
--- a/event.c
+++ b/event.c
@@ -30,6 +30,12 @@ event_t event_get(void)
     return event;
 }
 
+bool event_has(void)
+{
+    event_t event;
+    return queue_try_peek(&core0_evq, &event);
+}
+
 void event_print(event_t const *const ev)
 {
     if (ev->tag < ev_last)

--- a/event.h
+++ b/event.h
@@ -20,12 +20,20 @@ extern "C"
         ev_button_back_release,
         ev_button_push_press,
         ev_button_push_release,
+        ev_encoder,
         ev_last,
     } event_e;
 
     typedef struct
     {
         event_e tag;
+        union
+        {
+            struct
+            {
+                int32_t delta;
+            } encoder;
+        };
     } event_t;
 
     static const char *const event_to_str[] = {
@@ -37,6 +45,7 @@ extern "C"
         "ev_button_back_release",
         "ev_button_push_press",
         "ev_button_push_release",
+        "ev_encoder",
     };
 
     void event_init(void);

--- a/event.h
+++ b/event.h
@@ -3,6 +3,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C"
@@ -41,6 +42,7 @@ extern "C"
     void event_init(void);
     void event_send(event_t event);
     event_t event_get(void);
+    bool event_has(void);
     void event_print(event_t const *const ev);
 
 #ifdef __cplusplus

--- a/picorx.cpp
+++ b/picorx.cpp
@@ -84,8 +84,10 @@ int main()
   bool ret = add_repeating_timer_us(-1000000 / DEBOUNCE_TICK_HZ, io_callback, NULL, &io_timer);
   hard_assert(ret);
 
-  while(1)
+  while(true)
   {
+    user_interface.do_disp();
+    
     event_t event = event_get();
     if((1UL << event.tag) & (ev_ui_evset))
     {

--- a/ssd1306.c
+++ b/ssd1306.c
@@ -120,6 +120,7 @@ bool ssd1306_init(ssd1306_t *p, uint16_t width, uint16_t height, uint8_t address
     p->i2c_i=i2c_instance;
     p->curr_page=0;
     p->curr_buf=0;
+    p->show_pending = false;
 
     // 1 + p->width so each page is 129 bytes long
     // allows room for the 0x40 byte at the start of each page
@@ -392,6 +393,8 @@ void ssd1306_show(ssd1306_t *p)
         memcpy(p->buffer, &p->mem[p->bufsize * (p->curr_buf ^ 1)], p->bufsize); // needed for scrolling
         _draw_page(p);
         p->curr_page++;
+    } else {
+        p->show_pending = true;
     }
 }
 
@@ -406,6 +409,11 @@ bool ssd1306_show_continue(ssd1306_t *p)
         if (p->curr_page == p->pages)
         {
             p->curr_page = 0;
+            if(p->show_pending)
+            {
+                p->show_pending = false;
+                ssd1306_show(p);
+            }
         }
         else
         {

--- a/ssd1306.h
+++ b/ssd1306.h
@@ -76,6 +76,7 @@ typedef struct {
 	uint8_t curr_page;  /**< currently drawn page */
 	uint8_t curr_buf;
 	uint8_t disp_col_offset; /**< 0 for ssd1306, 2 for sh1106 */
+	bool show_pending;
 } ssd1306_t;
 
  void ssd1306_set_start_line(ssd1306_t *p, uint8_t val);

--- a/ssd1306.h
+++ b/ssd1306.h
@@ -71,7 +71,10 @@ typedef struct {
     i2c_inst_t *i2c_i; 	/**< i2c connection instance */
     bool external_vcc; 	/**< whether display uses external vcc */ 
     uint8_t *buffer;	/**< display buffer */
+	uint8_t *mem;	    /**< display memory */
     size_t bufsize;		/**< buffer size */
+	uint8_t curr_page;  /**< currently drawn page */
+	uint8_t curr_buf;
 	uint8_t disp_col_offset; /**< 0 for ssd1306, 2 for sh1106 */
 } ssd1306_t;
 
@@ -160,6 +163,16 @@ void ssd1306_type(ssd1306_t *p, uint8_t type);
 
 */
 void ssd1306_show(ssd1306_t *p);
+
+/**
+	@brief continue display buffer
+
+	@param[in] p : instance of display
+
+	* 	@return bool.
+	*	@retval true if finished
+*/
+bool ssd1306_show_continue(ssd1306_t *p);
 
 /**
 	@brief clear display buffer

--- a/ui.cpp
+++ b/ui.cpp
@@ -811,6 +811,7 @@ uint32_t ui::menu_entry(const char title[], const char options[], uint32_t *valu
       display_show();
     }
 
+    do_disp();  
     event_t ev = event_get();
     //select menu item
     if((ev.tag == ev_button_menu_press) || (ev.tag == ev_button_push_press)){
@@ -851,6 +852,7 @@ uint32_t ui::enumerate_entry(const char title[], const char options[], uint32_t 
       display_show();
     }
 
+    do_disp();
     event_t ev = event_get();
     //select menu item
     if((ev.tag == ev_button_menu_press) || (ev.tag == ev_button_push_press)){
@@ -883,6 +885,7 @@ int16_t ui::number_entry(const char title[], const char format[], int16_t min, i
       display_show();
     }
 
+    do_disp();
     event_t ev = event_get();
 
     //select menu item
@@ -1179,6 +1182,7 @@ bool ui::memory_store()
       display_show();
     }
 
+    do_disp();
     event_t ev = event_get();
 
     //select menu item
@@ -1367,6 +1371,7 @@ bool ui::memory_recall()
       display_show();
     }
 
+    do_disp();
     event_t ev = event_get();
 
     if(ev.tag == ev_button_push_press){
@@ -1582,6 +1587,7 @@ bool ui::memory_scan()
       display_show();
     }
 
+    do_disp();
     event_t ev = event_get();
 
     if(ev.tag == ev_button_push_press){
@@ -1821,6 +1827,7 @@ bool ui::frequency_scan()
       display_show();
     }
 
+    do_disp();
     event_t ev = event_get();
 
     if(ev.tag == ev_button_push_press){
@@ -1971,6 +1978,7 @@ int ui::string_entry(char string[]){
       display_show();
     }
 
+    do_disp();
     event_t ev = event_get();
 
     //select menu item
@@ -2054,6 +2062,7 @@ bool ui::frequency_entry(const char title[], uint32_t which_setting){
       display_show();
     }
 
+    do_disp();
     event_t ev = event_get();
 
     //select menu item
@@ -2132,6 +2141,7 @@ bool ui::display_timeout(bool encoder_change, event_t event)
         ssd1306_poweron(&disp);
         do
         {
+          do_disp();
           event = event_get();
         } while (((1UL << event.tag) & (ev_display_tmout_evset)));
         display_timer = display_timeout;
@@ -2164,6 +2174,7 @@ bool ui::configuration_menu()
   uint32_t setting = 0;
 
   while (1) {
+      do_disp();
       event_t ev = event_get();
       if(ev.tag == ev_button_back_press){
         break;
@@ -2247,6 +2258,7 @@ bool ui::scanner_radio_menu()
 
   while (1)
   {
+      do_disp();
       event_t ev = event_get();
       if(ev.tag == ev_button_back_press){
         break;
@@ -2306,6 +2318,7 @@ bool ui::scanner_menu()
   uint32_t setting = 0;
 
   while (1) {
+      do_disp();
       event_t ev = event_get();
       if(ev.tag == ev_button_back_press){
         break;
@@ -2568,6 +2581,7 @@ bool ui::top_menu(rx_settings & settings_to_apply)
 
   while (1)
   {
+      do_disp();
       event_t ev = event_get();
       if(ev.tag == ev_button_back_press){
         break;
@@ -2658,4 +2672,22 @@ ui::ui(rx_settings & settings_to_apply, rx_status & status, rx &receiver) : sett
   setup_encoder();
 
   button_state = idle;
+}
+
+void ui::do_disp(void)
+{
+    while (true)
+    {
+      if (ssd1306_show_continue(&disp))
+      {
+        break;
+      }
+      else
+      {
+        if (event_has())
+        {
+          break;
+        }
+      }
+    }
 }

--- a/ui.cpp
+++ b/ui.cpp
@@ -2318,6 +2318,7 @@ bool ui::configuration_menu()
             display_clear();
             display_print_str("Ready for\nfirmware",2, style_centered);
             display_show();
+            do_disp();
             reset_usb_boot(0,0);
           }
           break;

--- a/ui.h
+++ b/ui.h
@@ -200,6 +200,7 @@ class ui
   void autorestore();
   void do_ui(event_t event);
   ui(rx_settings & settings_to_apply, rx_status & status, rx &receiver);
+  void do_disp(void);
 
 };
 

--- a/ui.h
+++ b/ui.h
@@ -95,14 +95,9 @@ class ui
   // last selected memory
   int32_t last_select=0;
 
-  // Encoder 
-  void setup_encoder();
-  int32_t get_encoder_change();
-  int32_t encoder_control(int32_t *value, int32_t min, int32_t max);
-  int32_t new_position;
-  int32_t old_position;
-  const uint32_t sm = 0;
-  const PIO pio = pio1;
+  // Encoder
+  int32_t encoder_adjust_dir(int32_t position_change);
+  int32_t encoder_control(int32_t position_change, int32_t *value, int32_t min, int32_t max);
 
   // Buttons
   e_button_state button_state;


### PR DESCRIPTION
This is just a proposal. Tried to make it as pretty as possible.This essentially adds "pre-emption" point after every display page transfer. I would add some more sophisticated button event handling, but I can't do it because of more than 50ms blocking in `ssd1306_show`.