### PR TITLE
Switched to fixed 15k samplerate

### DIFF
--- a/picorx.cpp
+++ b/picorx.cpp
@@ -150,7 +150,8 @@ int main()
 
   // create an alarm pool for USB streaming with highest priority (0), so
   // that it can pre-empt the default pool used by IO which uses timer 3 (lowest priority)
-  receiver.set_alarm_pool(alarm_pool_create(0, 16));
+  irq_set_priority(TIMER_IRQ_1, PICO_HIGHEST_IRQ_PRIORITY);
+  receiver.set_alarm_pool(alarm_pool_create_on_timer(alarm_pool_timer_for_timer_num(1), 0, 16));
   
   multicore_launch_core1(core1_main);
   stdio_init_all();

--- a/rx.cpp
+++ b/rx.cpp
@@ -333,7 +333,7 @@ void rx::read_batt_temp()
   }
 }
 
-static bool usb_callback(repeating_timer_t *rt)
+static bool __not_in_flash_func(usb_callback)(repeating_timer_t *rt)
 {
   usb_audio_device_task();
   return true; // keep repeating
@@ -352,10 +352,10 @@ void rx::run()
 
     hard_assert(pool);
 
-    // here the delay theoretically should be 1000 (1ms = 1 / (16000 / 16))
+    // here the delay theoretically should be 1067 (1ms = 1 / (15000 / 16))
     // however the 'usb_microphone_task' should be called more often, but not too often
     // to save compute
-    bool ret = alarm_pool_add_repeating_timer_us(pool, 1000/2, usb_callback, NULL, &usb_timer);
+    bool ret = alarm_pool_add_repeating_timer_us(pool, 1067 / 2, usb_callback, NULL, &usb_timer);
     hard_assert(ret);
 
     while(true)
@@ -374,6 +374,7 @@ void rx::run()
       audio_running = false;
       hw_clear_bits(&adc_hw->fcs, ADC_FCS_UNDER_BITS);
       hw_clear_bits(&adc_hw->fcs, ADC_FCS_OVER_BITS);
+      adc_set_clkdiv(100 - 1);
       adc_fifo_setup(true, true, 1, false, false);
       adc_select_input(0);
       adc_set_round_robin(3);

--- a/rx_definitions.h
+++ b/rx_definitions.h
@@ -2,7 +2,7 @@
 #define RX_CONSTANTS
 #include <math.h>
 
-const uint32_t adc_sample_rate = 500e3;
+const uint32_t adc_sample_rate = 480e3;
 const uint32_t audio_sample_rate = adc_sample_rate/2;
 const uint8_t  adc_bits = 12u;
 const uint16_t adc_max=1<<(adc_bits-1);

--- a/simulations/am_sync_des.py
+++ b/simulations/am_sync_des.py
@@ -7,7 +7,7 @@ import scipy.signal as sig
 import matplotlib.pyplot as plt
 
 
-SR = 250000 // 32
+SR = 480000 // 32
 FIX_MAX = (1 << 15) - 1  # corresponds to 2*PI
 FIX_ONE = round(FIX_MAX / (2 * math.pi))
 

--- a/simulations/deemphasis.py
+++ b/simulations/deemphasis.py
@@ -5,7 +5,7 @@ from scipy import signal
 import matplotlib.pyplot as plt
 
 
-FS = 250000 // 32
+FS = 480000 // 32
 
 
 def to_fixed(arr):

--- a/usb_audio_device.h
+++ b/usb_audio_device.h
@@ -10,7 +10,7 @@
 
 #include "tusb.h"
 
-#define USB_A_SAMPLE_RATE (16000)
+#define USB_A_SAMPLE_RATE (15000)
 #define SAMPLE_BUFFER_SIZE ((CFG_TUD_AUDIO_EP_SZ_IN / 2) - 1)
 
 #ifdef __cplusplus


### PR DESCRIPTION
The software interpolated samplerate turned out to be problematic, especially when streaming USB audio from core0. This PR disables the interpolation and switches to 15ksps audio samplerate (+fixes and adjusts few minor things).