### PR TITLE
Fixed USB volume setting

### DIFF
--- a/rx.cpp
+++ b/rx.cpp
@@ -395,15 +395,15 @@ void rx::set_alarm_pool(alarm_pool_t *p)
 }
 
 critical_section_t usb_volumute;
-static int16_t usb_volume=180;  // usb volume
-static bool usb_mute = false;   // usb mute control
+static int16_t usb_volume = 32767;  // usb volume
+static bool usb_mute = false;     // usb mute control
 
 // usb mute setting = true is muted
 static void on_usb_set_mutevol(bool mute, int16_t vol)
 {
   //printf ("usbcb: got mute %d vol %d\n", mute, vol);
   critical_section_enter_blocking(&usb_volumute);
-  usb_volume = vol + 90; // defined as -90 to 90 => 0 to 180
+  usb_volume = 32767 * powf(10, (float)vol / (20 * 256));
   usb_mute = mute;
   critical_section_exit(&usb_volumute);
 }
@@ -458,7 +458,7 @@ uint16_t __not_in_flash_func(rx::process_block)(uint16_t adc_samples[], int16_t 
     if (safe_usb_mute) {
       usb_audio[idx] = 0;
     } else {
-      usb_audio[idx] = (usb_audio[idx] * safe_usb_volume)/180;
+      usb_audio[idx] = (usb_audio[idx] * safe_usb_volume) / 32767;
     }
   }
 

--- a/usb_audio_device.c
+++ b/usb_audio_device.c
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2020 Reinhard Panhuber
@@ -24,6 +24,22 @@
  */
 
 #include "usb_audio_device.h"
+
+enum
+{
+  VOLUME_CTRL_0_DB = 0,
+  VOLUME_CTRL_10_DB = 2560,
+  VOLUME_CTRL_20_DB = 5120,
+  VOLUME_CTRL_30_DB = 7680,
+  VOLUME_CTRL_40_DB = 10240,
+  VOLUME_CTRL_50_DB = 12800,
+  VOLUME_CTRL_60_DB = 15360,
+  VOLUME_CTRL_70_DB = 17920,
+  VOLUME_CTRL_80_DB = 20480,
+  VOLUME_CTRL_90_DB = 23040,
+  VOLUME_CTRL_100_DB = 25600,
+  VOLUME_CTRL_SILENCE = 0x8000,
+};
 
 // Audio controls
 // Current states
@@ -268,9 +284,9 @@ bool tud_audio_get_req_entity_cb(uint8_t rhport, tusb_control_request_t const * 
 	    audio_control_range_2_n_t(1) ret;
 
 	    ret.wNumSubRanges = 1;
-	    ret.subrange[0].bMin = -90; 	// -90 dB
-	    ret.subrange[0].bMax = 90;		// +90 dB
-	    ret.subrange[0].bRes = 1; 		// 1 dB steps
+	    ret.subrange[0].bMin = -VOLUME_CTRL_50_DB;  // -50 dB
+	    ret.subrange[0].bMax = VOLUME_CTRL_0_DB;    // +0 dB
+	    ret.subrange[0].bRes = 256;                 // 256 steps
 
 	    return tud_audio_buffer_and_schedule_control_xfer(rhport, p_request, (void*)&ret, sizeof(ret));
 


### PR DESCRIPTION
The main problem was that `bRes` was set to 1 and that meant 1 step of volume. The changes in this PR are based on internal examples in TinyUSB lib.