### PR TITLE
Button handling adjustments

### DIFF
--- a/button.cpp
+++ b/button.cpp
@@ -1,66 +1,54 @@
 #include "button.h"
-#include "pico/stdlib.h"
 
 #include <cstdio>
 
-button :: button(uint8_t gpio_num):gpio_num(gpio_num)
-{
-    button_state = up;
-    time_pressed = 0;
-    gpio_init(gpio_num);
-    gpio_set_dir(gpio_num, GPIO_IN);
-    gpio_pull_up(gpio_num);
+#include "pico/stdlib.h"
+
+button ::button(uint8_t gpio_num) : gpio_num(gpio_num) {
+  button_state = idle;
+  time_pressed = 0;
+  pressed_count = 0;
+  held_count = 0;
+
+  gpio_init(gpio_num);
+  gpio_set_dir(gpio_num, GPIO_IN);
+  gpio_pull_up(gpio_num);
 }
 
-void button :: update_state()
-{
-  if(button_state == up)
-  {
-    if(!gpio_get(gpio_num)) //on
+void button ::update_state() {
+  if (button_state == idle) {
+    if (!gpio_get(gpio_num))  // on
     {
       time_pressed = time_us_32();
-      button_state = down;
+      button_state = decoding;
     }
-  }
-  else if(button_state == down)
-  {
-    if((time_us_32() - time_pressed) > (500 * 1000))
+  } else if (button_state == decoding) {
+    if (gpio_get(gpio_num))  // off
     {
-      button_state = held;
-    }
-    else if(gpio_get(gpio_num)) //off
-    {
-      if((time_us_32() - time_pressed) > (50 * 1000))
-      {
-        button_state = pressed;
-      }
-      else
-      {
-        button_state = up;
+      pressed_count++;
+      button_state = idle;
+    } else {  // on
+      if ((time_us_32() - time_pressed) > (250UL * 1000)) {
+        held_count++;
+        button_state = active;
       }
     }
-  }
-  else if(button_state == pressed)
-  {
-    button_state = up;
-  }
-  else if(button_state == held)
-  {
-    if(gpio_get(gpio_num)) //off
+  } else if (button_state == active) {
+    if (gpio_get(gpio_num))  // off
     {
-      button_state = up;
+      held_count = 0;
+      button_state = idle;
     }
   }
 }
 
-bool button :: is_pressed()
-{
-  update_state();
-  return button_state == pressed;
+bool button ::is_pressed() {
+  bool ret = pressed_count > 0;
+  pressed_count = 0;
+  return ret;
 }
 
-bool button :: is_held()
-{
-  update_state();
-  return button_state == held;
+bool button ::is_held() {
+  bool ret = held_count > 0;
+  return ret;
 }

--- a/button.h
+++ b/button.h
@@ -9,13 +9,16 @@ class button
   button(uint8_t gpio_num);
   bool is_pressed();
   bool is_held();
-  private:
-  uint8_t gpio_num;
   void update_state();
 
-  enum e_button_state {up, down, pressed, held};
-  e_button_state button_state = up;
+  private:
+  uint8_t gpio_num;
+
+  enum e_button_state {idle, decoding, active};
+  e_button_state button_state = idle;
   uint32_t time_pressed = 0;
+  uint8_t pressed_count;
+  uint8_t held_count;
 
 };
 

--- a/picorx.cpp
+++ b/picorx.cpp
@@ -12,6 +12,7 @@
 #define UI_REFRESH_HZ (10UL)
 #define UI_REFRESH_US (1000000UL / UI_REFRESH_HZ)
 #define CAT_REFRESH_US (10000UL)
+#define BUTTONS_REFRESH_US (50000UL) // 50ms <=> 20Hz
 
 uint8_t spectrum[256];
 uint8_t dB10=10;
@@ -40,9 +41,16 @@ int main()
 
   uint32_t last_ui_update = 0;
   uint32_t last_cat_update = 0;
+  uint32_t last_buttons_update = 0;
+
   while(1)
   {
     //schedule tasks
+    if (time_us_32() - last_buttons_update > BUTTONS_REFRESH_US) {
+      last_buttons_update = time_us_32();
+      user_interface.update_buttons();
+    }
+
     if(time_us_32() - last_ui_update > UI_REFRESH_US)
     {
       last_ui_update = time_us_32();

--- a/ui.cpp
+++ b/ui.cpp
@@ -2884,6 +2884,13 @@ void ui::update_display_type(void)
   }
 }
 
+void ui::update_buttons(void)
+{
+  menu_button.update_state();
+  back_button.update_state();
+  encoder_button.update_state();
+}
+
 ui::ui(rx_settings & settings_to_apply, rx_status & status, rx &receiver, uint8_t *spectrum, uint8_t &dB10, waterfall &waterfall_inst) : 
   menu_button(PIN_MENU), 
   back_button(PIN_BACK), 

--- a/ui.h
+++ b/ui.h
@@ -244,6 +244,7 @@ class ui
   uint32_t * get_settings(){return &settings[0];};
   void autorestore();
   void do_ui();
+  void update_buttons(void);
   ui(rx_settings & settings_to_apply, rx_status & status, rx &receiver, uint8_t *spectrum, uint8_t &dB10, waterfall &waterfall_inst);
 
 };


### PR DESCRIPTION
We were occasionally missing button presses. The main problem was that button decoding was being made with the frequency of the UI update which is 10Hz, so 100ms. This is a little bit too slow for button decoding. This PR separates the button decoding rate from the UI update rate and increases it to 20Hz (50ms). As a bonus the button decoding logic became a little simpler (I think) and "button hold" detection is now a little bit faster.