### PR TITLE
Added button encoder driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,30 +24,38 @@ add_library(
 )
 target_compile_options(u8g2 PRIVATE -Wno-unused-function -Wno-unused-variable)
 
+set(SRCS 
+    ssd1306.c
+    picorx.cpp
+    nco.cpp
+    rx.cpp
+    rx_dsp.cpp
+    fft.cpp
+    fft_filter.cpp
+    cic_corrections.cpp
+    ui.cpp
+    utils.cpp
+    ili934x.cpp
+    waterfall.cpp
+    button.cpp
+    cat.cpp
+    noise_canceler.cpp
+    usb_descriptors.c
+    usb_audio_device.c
+    ring_buffer_lib.c
+)
+
+if(BUTTON_ENCODER)
+    add_definitions(-DBUTTON_ENCODER)
+    list(APPEND SRCS button_encoder.cpp)
+else()
+    list(APPEND SRCS rotary_encoder.cpp)
+endif()
+
 if(PICO_BOARD STREQUAL "pico")
 
   #main application
-  add_executable(picorx
-      ssd1306.c
-      picorx.cpp
-      nco.cpp
-      rx.cpp
-      rx_dsp.cpp
-      fft.cpp
-      fft_filter.cpp
-      cic_corrections.cpp
-      ui.cpp
-      utils.cpp
-      ili934x.cpp
-      waterfall.cpp
-      button.cpp
-      cat.cpp
-      rotary_encoder.cpp
-      noise_canceler.cpp
-      usb_descriptors.c
-      usb_audio_device.c
-      ring_buffer_lib.c
-  )
+  add_executable(picorx ${SRCS})
 
   pico_generate_pio_header(picorx ${CMAKE_CURRENT_LIST_DIR}/nco.pio)
   pico_generate_pio_header(picorx ${CMAKE_CURRENT_LIST_DIR}/quadrature_encoder.pio)
@@ -87,27 +95,7 @@ elseif(PICO_BOARD STREQUAL "pico2")
   if(PICO_PLATFORM STREQUAL "rp2350-riscv")
 
     #main application
-    add_executable(pico2rx-riscv
-      ssd1306.c
-      picorx.cpp
-      nco.cpp
-      rx.cpp
-      rx_dsp.cpp
-      fft.cpp
-      fft_filter.cpp
-      cic_corrections.cpp
-      ui.cpp
-      utils.cpp
-      ili934x.cpp
-      waterfall.cpp
-      button.cpp
-      cat.cpp
-      rotary_encoder.cpp
-      noise_canceler.cpp
-      usb_descriptors.c
-      usb_audio_device.c
-      ring_buffer_lib.c
-    )
+    add_executable(pico2rx-riscv ${SRCS})
     pico_generate_pio_header(pico2rx-riscv ${CMAKE_CURRENT_LIST_DIR}/nco.pio)
     pico_generate_pio_header(pico2rx-riscv ${CMAKE_CURRENT_LIST_DIR}/quadrature_encoder.pio)
     pico_add_extra_outputs(pico2rx-riscv)
@@ -143,27 +131,7 @@ elseif(PICO_BOARD STREQUAL "pico2")
   else()
 
     #main application
-    add_executable(pico2rx
-      ssd1306.c
-      picorx.cpp
-      nco.cpp
-      rx.cpp
-      rx_dsp.cpp
-      fft.cpp
-      fft_filter.cpp
-      cic_corrections.cpp
-      ui.cpp
-      utils.cpp
-      ili934x.cpp
-      waterfall.cpp
-      button.cpp
-      cat.cpp
-      rotary_encoder.cpp
-      noise_canceler.cpp
-      usb_descriptors.c
-      usb_audio_device.c
-      ring_buffer_lib.c
-    )
+    add_executable(pico2rx ${SRCS})
     pico_generate_pio_header(pico2rx ${CMAKE_CURRENT_LIST_DIR}/nco.pio)
     pico_generate_pio_header(pico2rx ${CMAKE_CURRENT_LIST_DIR}/quadrature_encoder.pio)
     pico_add_extra_outputs(pico2rx)

--- a/button_encoder.cpp
+++ b/button_encoder.cpp
@@ -1,0 +1,84 @@
+#include "button_encoder.h"
+
+#include <algorithm>
+
+#include "ui.h"
+
+static const uint32_t LEVELS = 6;
+static const uint32_t TRESHOLD_US = 1000000;
+
+static const uint8_t PIN_A = 20;
+static const uint8_t PIN_B = 21;
+
+static const uint32_t rates[LEVELS] = {200000, 100000, 50000,
+                                       20000,  20000,  20000};
+
+static const uint8_t increments[LEVELS] = {1, 1, 1, 1, 2, 4};
+
+button_encoder::button_encoder(const uint32_t (&settings)[16])
+    : encoder(settings) {
+  gpio_init(PIN_A);
+  gpio_set_dir(PIN_A, GPIO_IN);
+  gpio_pull_up(PIN_A);
+  gpio_init(PIN_B);
+  gpio_set_dir(PIN_B, GPIO_IN);
+  gpio_pull_up(PIN_B);
+}
+
+int32_t button_encoder::get_change(void) {
+  int32_t delta = new_position - old_position;
+  old_position = new_position;
+  if ((settings[idx_hw_setup] >> flag_reverse_encoder) & 1) {
+    return -delta;
+  } else {
+    return delta;
+  }
+}
+
+void button_encoder::update(void) {
+  const uint32_t now = time_us_32();
+
+  switch (state) {
+    case idle:
+      if (!gpio_get(PIN_A)) {
+        start_time = now;
+        update_time = now;
+        state = right;
+        new_position++;
+      } else if (!gpio_get(PIN_B)) {
+        start_time = now;
+        update_time = now;
+        state = left;
+        new_position--;
+      }
+      break;
+
+    case right:
+      if (gpio_get(PIN_A)) {
+        state = idle;
+      } else {
+        const uint32_t level =
+            std::min((now - start_time) / TRESHOLD_US, LEVELS - 1);
+
+        if ((now - update_time) > rates[level]) {
+          new_position += increments[level];
+          update_time = now;
+        }
+      }
+      break;
+
+    case left:
+      if (gpio_get(PIN_B)) {
+        state = idle;
+      } else {
+        const uint32_t level =
+            std::min((now - start_time) / TRESHOLD_US, LEVELS - 1);
+
+        if ((now - update_time) > rates[level]) {
+          new_position -= increments[level];
+          update_time = now;
+        }
+      }
+      break;
+  }
+}

--- a/button_encoder.h
+++ b/button_encoder.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "encoder.h"
+#include "hardware/pio.h"
+
+class button_encoder : public encoder {
+ public:
+  button_encoder(const uint32_t (&settings)[16]);
+  int32_t get_change(void);
+  void update(void);
+
+ private:
+  enum e_button_encoder_state { idle, right, left };
+  e_button_encoder_state state = idle;
+  uint32_t start_time = 0;
+  uint32_t update_time = 0;
+};

--- a/ui.cpp
+++ b/ui.cpp
@@ -2894,6 +2894,9 @@ void ui::update_buttons(void)
   menu_button.update_state();
   back_button.update_state();
   encoder_button.update_state();
+#ifdef BUTTON_ENCODER
+  main_encoder.update();
+#endif
 }
 
 ui::ui(rx_settings & settings_to_apply, rx_status & status, rx &receiver, uint8_t *spectrum, uint8_t &dB10, waterfall &waterfall_inst) : 

--- a/ui.h
+++ b/ui.h
@@ -121,7 +121,7 @@ class ui
 
   private:
 
-  uint32_t settings[16];
+  uint32_t settings[16] = {0};
   const uint32_t timeout_lookup[8] = {0, 5000000, 10000000, 15000000, 30000000, 60000000, 120000000, 240000000};
   const char modes[6][4]  = {" AM", "AMS", "LSB", "USB", " FM", " CW"};
   const char steps[11][8]  = {

--- a/ui.h
+++ b/ui.h
@@ -13,7 +13,11 @@
 #include "autosave_memory.h"
 #include "waterfall.h"
 #include "button.h"
+#ifdef BUTTON_ENCODER
+#include "button_encoder.h"
+#else
 #include "rotary_encoder.h"
+#endif
 #include "logo.h"
 #include "u8g2.h"
 
@@ -131,8 +135,11 @@ class ui
     "S9+30dB---|"};
 
   // Encoder
+#ifdef BUTTON_ENCODER
+  button_encoder main_encoder;
+#else
   rotary_encoder main_encoder;
-
+#endif
 
   // Buttons
   button menu_button;


### PR DESCRIPTION
and some CMakeLists.txt cleanups
The button encoder driver can be enabled by adding `-DBUTTON_ENCODER=1` to cmake command.