### PR TITLE
Separated the PWM sound output/sink code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SRCS
     button.cpp
     cat.cpp
     noise_canceler.cpp
+    pwm_audio_sink.cpp
     usb_descriptors.c
     usb_audio_device.c
     ring_buffer_lib.c

--- a/pwm_audio_sink.cpp
+++ b/pwm_audio_sink.cpp
@@ -1,0 +1,108 @@
+#include "pwm_audio_sink.h"
+
+#include "hardware/dma.h"
+#include "hardware/gpio.h"
+#include "hardware/irq.h"
+#include "hardware/pwm.h"
+#include "pico/sync.h"
+
+#define AUDIO_PIN (16)
+
+#define NUM_OUT_SAMPLES (PWM_AUDIO_NUM_SAMPLES * interpolation_rate)
+
+static int audio_pwm_slice_num;
+static int pwm_dma_ping;
+static int pwm_dma_pong;
+static dma_channel_config audio_ping_cfg;
+static dma_channel_config audio_pong_cfg;
+
+static int16_t ping_audio[NUM_OUT_SAMPLES];
+static int16_t pong_audio[NUM_OUT_SAMPLES];
+
+static uint32_t pwm_max;
+static uint32_t pwm_scale;
+
+static void interpolate(int16_t sample, int16_t pwm_samples[], int16_t gain) {
+  // digital volume control
+  sample = ((int32_t)sample * gain) >> 8;
+
+  // shift up
+  sample += INT16_MAX;
+  sample = (uint16_t)sample / pwm_scale;
+
+  // interpolate to PWM rate
+  static int16_t last_sample = 0;
+  int32_t comb = sample - last_sample;
+  last_sample = sample;
+  for (uint8_t subsample = 0; subsample < interpolation_rate; ++subsample) {
+    static int32_t integrator = 0;
+    integrator += comb;
+    pwm_samples[subsample] = integrator >> 4;
+  }
+}
+
+void pwm_audio_sink_init(void) {
+  gpio_set_function(AUDIO_PIN, GPIO_FUNC_PWM);
+  gpio_set_drive_strength(AUDIO_PIN, GPIO_DRIVE_STRENGTH_12MA);
+  audio_pwm_slice_num = pwm_gpio_to_slice_num(AUDIO_PIN);
+  pwm_config config = pwm_get_default_config();
+  pwm_config_set_clkdiv(&config, 1.f);
+  pwm_config_set_wrap(&config, pwm_max);
+  pwm_init(audio_pwm_slice_num, &config, true);
+
+  pwm_dma_ping = dma_claim_unused_channel(true);
+  pwm_dma_pong = dma_claim_unused_channel(true);
+  audio_ping_cfg = dma_channel_get_default_config(pwm_dma_ping);
+  audio_pong_cfg = dma_channel_get_default_config(pwm_dma_pong);
+
+  channel_config_set_transfer_data_size(&audio_ping_cfg, DMA_SIZE_16);
+  channel_config_set_read_increment(&audio_ping_cfg, true);
+  channel_config_set_write_increment(&audio_ping_cfg, false);
+  channel_config_set_dreq(&audio_ping_cfg,
+                          DREQ_PWM_WRAP0 + audio_pwm_slice_num);
+
+  channel_config_set_transfer_data_size(&audio_pong_cfg, DMA_SIZE_16);
+  channel_config_set_read_increment(&audio_pong_cfg, true);
+  channel_config_set_write_increment(&audio_pong_cfg, false);
+  channel_config_set_dreq(&audio_pong_cfg,
+                          DREQ_PWM_WRAP0 + audio_pwm_slice_num);
+}
+
+void pwm_audio_sink_start(void) {
+  dma_channel_configure(pwm_dma_ping, &audio_ping_cfg,
+                        &pwm_hw->slice[audio_pwm_slice_num].cc, ping_audio,
+                        NUM_OUT_SAMPLES, false);
+  dma_channel_configure(pwm_dma_pong, &audio_pong_cfg,
+                        &pwm_hw->slice[audio_pwm_slice_num].cc, pong_audio,
+                        NUM_OUT_SAMPLES, false);
+}
+
+void pwm_audio_sink_stop(void) {
+  dma_channel_cleanup(pwm_dma_ping);
+  dma_channel_cleanup(pwm_dma_pong);
+}
+
+void pwm_audio_sink_push(int16_t samples[PWM_AUDIO_NUM_SAMPLES], int16_t gain) {
+  static bool toggle = false;
+  if (toggle) {
+    for (uint16_t i = 0; i < PWM_AUDIO_NUM_SAMPLES; i++) {
+      interpolate(samples[i], &ping_audio[i << 4], gain);
+    }
+    dma_channel_wait_for_finish_blocking(pwm_dma_pong);
+    dma_channel_set_read_addr(pwm_dma_ping, ping_audio, true);
+  } else {
+    for (uint16_t i = 0; i < PWM_AUDIO_NUM_SAMPLES; i++) {
+      interpolate(samples[i], &pong_audio[i << 4], gain);
+    }
+    dma_channel_wait_for_finish_blocking(pwm_dma_ping);
+    dma_channel_set_read_addr(pwm_dma_pong, pong_audio, true);
+  }
+  toggle ^= 1;
+}
+
+void pwm_audio_sink_update_pwm_max(uint32_t new_max) {
+  pwm_max = new_max;
+  pwm_scale = 1 + ((INT16_MAX * 2) / pwm_max);
+  pwm_set_wrap(audio_pwm_slice_num, pwm_max);
+  pwm_set_gpio_level(AUDIO_PIN, (pwm_max / 2));
+}

--- a/pwm_audio_sink.h
+++ b/pwm_audio_sink.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <stdint.h>
+#include <rx_definitions.h>
+ 
+#define PWM_AUDIO_NUM_SAMPLES (adc_block_size / decimation_rate)
+
+void pwm_audio_sink_init(void);
+void pwm_audio_sink_start(void);
+void pwm_audio_sink_stop(void);
+void pwm_audio_sink_push(int16_t samples[PWM_AUDIO_NUM_SAMPLES], int16_t gain);
+void pwm_audio_sink_update_pwm_max(uint32_t new_max);

--- a/rx.h
+++ b/rx.h
@@ -60,8 +60,6 @@ class rx
 {
   private:
 
-  void pwm_ramp_down();
-  void pwm_ramp_up();
   void update_status();
   void set_usb_callbacks();
 
@@ -91,22 +89,10 @@ class rx
   static dma_channel_config pong_cfg;
   static uint16_t ping_samples[adc_block_size];
   static uint16_t pong_samples[adc_block_size];
-  static uint16_t num_ping_samples;
-  static uint16_t num_pong_samples;
 
-  //buffers and dma for PWM audio output
-  static int audio_pwm_slice_num;
-  static int pwm_dma_ping;
-  static int pwm_dma_pong;
-  static dma_channel_config audio_ping_cfg;
-  static dma_channel_config audio_pong_cfg;
-  static int16_t ping_audio[adc_block_size];
-  static int16_t pong_audio[adc_block_size];
   static bool audio_running;
   static void dma_handler();
-  uint32_t pwm_max;
-  uint32_t pwm_scale;
-  uint16_t process_block(uint16_t adc_samples[], int16_t pwm_audio[]);
+  void process_block(uint16_t adc_samples[], int16_t audio[]);
   
   //store busy time for performance monitoring
   uint32_t busy_time;


### PR DESCRIPTION
Factored-out the PWM sound output code and introduced some changes:
 - slow ramping up and down of audio while tuning is removed - the clicking is only minor (different small countermeasure was implemented). Tuning is now faster without cutting-out of audio.
 - synchronization with the PWM DMA is now explicit. Previously there was a chance that some PWM samples could be lost.
 - the code is a little bit more decoupled and it will be easier to add more features in the future.