### PR TITLE
Switched to CORDIC-only phase and magnitude calculation

### DIFF
--- a/fft_filter.cpp
+++ b/fft_filter.cpp
@@ -56,7 +56,8 @@ void fft_filter::filter_block(int16_t sample_real[], int16_t sample_imag[], s_fi
   if(filter_control.capture)
   {
     for (uint16_t i = 0; i < fft_size; i++) {
-      magnitudes[i] = rectangular_2_magnitude(sample_real[i], sample_imag[i]);
+      int16_t phi;
+      rectangular_2_polar(sample_real[i], sample_imag[i], &magnitudes[i], &phi);
       capture[i] = (((int32_t)capture[i]<<3) - capture[i] + magnitudes[i]) >> 3;
     }
   }

--- a/rx_dsp.h
+++ b/rx_dsp.h
@@ -35,7 +35,7 @@ class rx_dsp
   
   void frequency_shift(int16_t &i, int16_t &q);
   bool decimate(int16_t &i, int16_t &q);
-  int16_t demodulate(int16_t i, int16_t q, uint16_t m);
+  int16_t demodulate(int16_t i, int16_t q, uint16_t mag, int16_t phi);
   int16_t automatic_gain_control(int16_t audio);
   int16_t apply_deemphasis(int16_t x);
   int16_t apply_treble(int16_t x);

--- a/simulations/mag_estimator.py
+++ b/simulations/mag_estimator.py
@@ -7,57 +7,101 @@ import matplotlib.pyplot as plt
 
 SRC = """
 
-uint16_t rectangular_2_magnitude_1(int16_t i, int16_t q)
+int16_t rectangular_2_phase(int16_t i, int16_t q)
+{
+
+   //handle condition where phase is unknown
+   if(i==0 && q==0) return 0;
+
+   const int16_t absi=i>0?i:-i;
+   int16_t angle=0;
+   if (q>=0)
+   {
+      //scale r so that it lies in range -8192 to 8192
+      const int16_t r = ((int32_t)(q - absi) << 13) / (q + absi);
+      angle = 8192 - r;
+   }
+   else
+   {
+      //scale r so that it lies in range -8192 to 8192
+      const int16_t r = ((int32_t)(q + absi) << 13) / (absi - q);
+      angle = (3 * 8192) - r;
+   }
+
+   //angle lies in range -32768 to 32767
+   if (i < 0) return(-angle);     // negate if in quad III or IV
+   else return(angle);
+}
+
+void rectangular_2_polar_1(int16_t i, int16_t q, uint16_t *mag, int16_t *phase)
 {
   //Measure magnitude
   const int16_t absi = i>0?i:-i;
   const int16_t absq = q>0?q:-q;
-  return absi > absq ? absi + absq / 4 : absq + absi / 4;
+  *mag = absi > absq ? absi + absq / 4 : absq + absi / 4;
+  *phase = rectangular_2_phase(q, i);
 }
 
-uint16_t rectangular_2_magnitude_f(int16_t i, int16_t q)
+void rectangular_2_polar_f(int16_t i, int16_t q, uint16_t *mag, int16_t *phase)
 {
-  float i_f = (float)i / 32767;
-  float q_f = (float)q / 32767;
-  return sqrtf(i_f * i_f + q_f * q_f) * 32767;
+  float i_f = (float)i / 32768;
+  float q_f = (float)q / 32768;
+  *mag = sqrtf(i_f * i_f + q_f * q_f) * 32768;
+  *phase = (atan2f(q, i) / (M_PI)) * 32768;
 }
 
-uint16_t rectangular_2_magnitude_2(int16_t i, int16_t q) {
-  int16_t tempI;
+void rectangular_2_polar_2(int16_t i, int16_t q, uint16_t *mag, int16_t *phase) {
+  int16_t temp_i;
+  int16_t angle = 0;
 
-  if (i < 0 && q >= 0) {
-    i = std::abs(i);
-  } else if (i < 0 && q < 0) {
-    i = std::abs(i);
-    q = std::abs(q);
+  if (i < 0) {
+    // rotate by an initial +/- 90 degrees
+    temp_i = i;
+    if (q > 0.0f) {
+      i = q; // subtract 90 degrees
+      q = -temp_i;
+      angle = 16384;
+    } else {
+      i = -q; // add 90 degrees
+      q = temp_i;
+      angle = -16384;
+    }
   }
 
-  for (uint16_t k = 0; k < ITERS; k++) {
-    tempI = i;
+  for (uint16_t k = 0; k < CORDIC_ITERS; k++) {
+    temp_i = i;
     if (q > 0) {
       /* Rotate clockwise */
       i += (q >> k);
-      q -= (tempI >> k);
+      q -= (temp_i >> k);
+      angle += CORDIC_ATAN_LUT[k];
     } else {
       /* Rotate counterclockwise */
       i -= (q >> k);
-      q += (tempI >> k);
+      q += (temp_i >> k);
+      angle -= CORDIC_ATAN_LUT[k];
     }
   }
-  uint16_t m = ((uint32_t)i * GAIN) >> 16;
-  return m;
+
+  *mag = ((uint32_t)i * CORDIC_GAIN) >> 16;
+  *phase = angle;
 }
 """
 
-iters = 4
+iters = 6
 gain = np.prod([1 / (math.sqrt(1 + math.pow(2, -2 * i))) for i in range(iters)])
-gain += 0.0015
 print(f"GAIN: ({gain})")
+
+atan_lut = [str(round(float(32768 * np.atan(2**-i) / np.pi))) for i in range(iters)]
+atan_lut = ", ".join(atan_lut)
+
+gain = round(gain * (1 << 16))
 
 SRC = "\n".join(
     [
-        f"#define ITERS ({iters})",
-        f"static const uint32_t GAIN = roundf({gain}f * (1 << 16));",
+        f"#define CORDIC_ITERS ({iters})",
+        f"static const uint32_t CORDIC_GAIN = {gain};",
+        f"static const int16_t CORDIC_ATAN_LUT[CORDIC_ITERS] = {{{atan_lut}}};",
         SRC,
     ]
 )
@@ -70,35 +114,56 @@ ffi.set_source(
     source_extension=".cpp",
 )
 
-ffi.cdef("uint16_t rectangular_2_magnitude_f(int16_t i, int16_t q);")
-ffi.cdef("uint16_t rectangular_2_magnitude_1(int16_t i, int16_t q);")
-ffi.cdef("uint16_t rectangular_2_magnitude_2(int16_t i, int16_t q);")
+# print(SRC)
+
+ffi.cdef("void rectangular_2_polar_f(int16_t i, int16_t q, uint16_t *mag, int16_t *phase);")
+ffi.cdef("void rectangular_2_polar_1(int16_t i, int16_t q, uint16_t *mag, int16_t *phase);")
+ffi.cdef("void rectangular_2_polar_2(int16_t i, int16_t q, uint16_t *mag, int16_t *phase);")
 ffi.compile()
 
 from _mag import lib
 
 time = np.arange(0, 0.05, 1 / 15000)
-s = np.sin(2 * np.pi * 100 * time) * np.sin(2 * np.pi * 10 * time) * 32767 * 0.1
+s = np.sin(2 * np.pi * 100 * time) * np.sin(2 * np.pi * 10 * time) * 32768 * 0.1
 a = sig.hilbert(s)
 
 mag_f = []
 mag_1 = []
 mag_2 = []
+phi_f = []
+phi_1 = []
+phi_2 = []
+
+m = ffi.new("uint16_t*")
+p = ffi.new("int16_t *")
 
 for iq in a:
     i = int(np.real(iq))
     q = int(np.imag(iq))
 
-    m = lib.rectangular_2_magnitude_f(i, q)
-    mag_f.append(m)
-    m = lib.rectangular_2_magnitude_1(i, q)
-    mag_1.append(m)
-    m = lib.rectangular_2_magnitude_2(i, q)
-    mag_2.append(m)
+    lib.rectangular_2_polar_f(i, q, m, p)
+    mag_f.append(m[0])
+    phi_f.append(p[0])
+    lib.rectangular_2_polar_1(i, q, m, p)
+    mag_1.append(m[0])
+    phi_1.append(p[0])
+    lib.rectangular_2_polar_2(i, q, m, p)
+    mag_2.append(m[0])
+    phi_2.append(p[0])
 
+plt.title("Magnitude")
 plt.plot(time, mag_f, label="ground truth")
 plt.plot(time, mag_1, label="basic estimator")
 plt.plot(time, mag_2, label="cordic estimator")
+plt.plot(time, s, label="test signal")
+plt.grid(True)
+plt.legend()
+plt.show()
+
+plt.title("Phase")
+plt.plot(time, phi_f, label="ground truth")
+plt.plot(time, phi_1, label="basic estimator")
+plt.plot(time, phi_2, label="cordic estimator")
 plt.plot(time, s, label="test signal")
 plt.grid(True)
 plt.legend()

--- a/utils.cpp
+++ b/utils.cpp
@@ -2,62 +2,50 @@
 #include <cstdint>
 #include <math.h>
 
+#include "pico/stdlib.h"
+
+#define CORDIC_ITERS (6)
+
 int16_t sin_table[2048];
 
-static const uint32_t GAIN = roundf(0.610334f * (1 << 16));
+static const uint32_t CORDIC_GAIN = 39803;
+static int16_t CORDIC_ATAN_LUT[CORDIC_ITERS] = {8192, 4836, 2555, 1297, 651, 326};
 
-uint16_t rectangular_2_magnitude(int16_t i, int16_t q) {
-  int16_t tempI;
+void __time_critical_func(rectangular_2_polar)(int16_t i, int16_t q, uint16_t *mag, int16_t *phase) {
+  int16_t temp_i;
+  int16_t angle = 0;
 
-  if (i < 0 && q >= 0) {
-    i = std::abs(i);
-  } else if (i < 0 && q < 0) {
-    i = std::abs(i);
-    q = std::abs(q);
+  if (i < 0) {
+    // rotate by an initial +/- 90 degrees
+    temp_i = i;
+    if (q > 0.0f) {
+      i = q; // subtract 90 degrees
+      q = -temp_i;
+      angle = 16384;
+    } else {
+      i = -q; // add 90 degrees
+      q = temp_i;
+      angle = -16384;
+    }
   }
 
-  for (uint16_t k = 0; k < 4; k++) {
-    tempI = i;
+  for (uint16_t k = 0; k < CORDIC_ITERS; k++) {
+    temp_i = i;
     if (q > 0) {
       /* Rotate clockwise */
       i += (q >> k);
-      q -= (tempI >> k);
+      q -= (temp_i >> k);
+      angle += CORDIC_ATAN_LUT[k];
     } else {
       /* Rotate counterclockwise */
       i -= (q >> k);
-      q += (tempI >> k);
+      q += (temp_i >> k);
+      angle -= CORDIC_ATAN_LUT[k];
     }
   }
-  uint16_t m = ((uint32_t)i * GAIN) >> 16;
-  return m;
-}
 
-//from: https://dspguru.com/dsp/tricks/fixed-point-atan2-with-self-normalization/
-//converted to fixed point
-int16_t rectangular_2_phase(int16_t i, int16_t q)
-{
-
-   //handle condition where phase is unknown
-   if(i==0 && q==0) return 0;
-
-   const int16_t absi=i>0?i:-i;
-   int16_t angle=0;
-   if (q>=0)
-   {
-      //scale r so that it lies in range -8192 to 8192
-      const int16_t r = ((int32_t)(q - absi) << 13) / (q + absi);
-      angle = 8192 - r;
-   }
-   else
-   {
-      //scale r so that it lies in range -8192 to 8192
-      const int16_t r = ((int32_t)(q + absi) << 13) / (absi - q);
-      angle = (3 * 8192) - r;
-   }
-
-   //angle lies in range -32768 to 32767
-   if (i < 0) return(-angle);     // negate if in quad III or IV
-   else return(angle);
+  *mag = ((uint32_t)i * CORDIC_GAIN) >> 16;
+  *phase = angle;
 }
 
 void initialise_luts()

--- a/utils.h
+++ b/utils.h
@@ -4,11 +4,8 @@
 #include <cstdint>
 
 extern int16_t sin_table[2048];
-//from: http://dspguru.com/dsp/tricks/magnitude-estimator/
-uint16_t rectangular_2_magnitude(int16_t i, int16_t q);
-//from: https://dspguru.com/dsp/tricks/fixed-point-atan2-with-self-normalization/
-int16_t rectangular_2_phase(int16_t i, int16_t q);
 
+void rectangular_2_polar(int16_t i, int16_t q, uint16_t *mag, int16_t *phase);
 void initialise_luts();
 
 #endif


### PR DESCRIPTION
Putting this out there for testing. There is noticeable increase in CPU load even with 6 iterations. More iterations is probably out of question. Phase has those little jumps:
![phase_jumps](https://github.com/user-attachments/assets/d6994b19-d502-490d-894e-9c41a506665b)
and it seems to be that the PLL has a harder time to sync, but might just be an illusion.
The biggest change I noticed is that the waterfall has more details visible.