### PR TITLE
Added 3rd-order PLL in synchronous AM demodulator

### DIFF
--- a/rx_dsp.cpp
+++ b/rx_dsp.cpp
@@ -363,16 +363,24 @@ bool __not_in_flash_func(rx_dsp :: decimate)(int16_t &i, int16_t &q)
       return false;
 }
 
-// PLL loop bandwidth: 50Hz
-#define AMSYNC_B0 (1956)
-#define AMSYNC_B1 (-1927)
-#define AMSYNC_PI (205884)
-#define AMSYNC_ONE (65535)
-#define AMSYNC_MAX (524287)
-#define AMSYNC_ERR_SCALE (6)
-#define AMSYNC_PHI_SCALE (201)
-#define AMSYNC_FRACTION_BITS (16)
+// For the formulas see 'PicoRX/simulations/am_sync_des.py:pll_3rd_order_des'
+// PLL loop bandwidth: 30Hz
+#define AMSYNC_NUM_TAPS (3)
+#define AMSYNC_B0 (1160)
+#define AMSYNC_B1 (-2306)
+#define AMSYNC_B2 (1146)
+#define AMSYNC_A0 (32767)
+#define AMSYNC_A1 (-65534)
+#define AMSYNC_A2 (32767)
+#define AMSYNC_PI (102941)
+#define AMSYNC_ONE (32767)
+#define AMSYNC_MAX (262143)
+#define AMSYNC_ERR_SCALE (3)
+#define AMSYNC_PHI_SCALE (101)
+#define AMSYNC_FRACTION_BITS (15)
 #define AMSYNC_BASE_FRACTION_BITS (15)
+#define AMSYNC_FILT_BITS (15)
+#define AMSYNC_FILT_ONE (32767)
 
 inline int32_t wrap(int32_t x) {
   if (x > AMSYNC_PI) {
@@ -387,7 +395,9 @@ int16_t __not_in_flash_func(rx_dsp :: demodulate)(int16_t i, int16_t q, uint16_t
 {
     static int32_t phase_locked = 0;
     static int32_t x1 = 0;
+    static int32_t x2 = 0;
     static int32_t y1 = 0;
+    static int32_t y2 = 0;
     static int32_t y0_err = 0;
 
     int16_t frequency = phase - last_phase;
@@ -420,16 +430,22 @@ int16_t __not_in_flash_func(rx_dsp :: demodulate)(int16_t i, int16_t q, uint16_t
       const int16_t synced_i = (i * vco_i + q * vco_q) >> AMSYNC_BASE_FRACTION_BITS;
       const int16_t synced_q = (-i * vco_q + q * vco_i) >> AMSYNC_BASE_FRACTION_BITS;
 
-      rectangular_2_polar(synced_i, synced_q, &magnitude, &phase);
-      const int32_t err = (int32_t)phase * AMSYNC_ERR_SCALE;
+      int16_t phi;
+      uint16_t mag;
 
-      int32_t y0 = err * AMSYNC_B0 + x1 * AMSYNC_B1;
+      rectangular_2_polar(synced_i, synced_q, &mag, &phi);
+
+      const int32_t phi_err = ((int32_t)phi * AMSYNC_ERR_SCALE);
+
+      int32_t y0 = phi_err * AMSYNC_B0 + x1 * AMSYNC_B1 + x2 * AMSYNC_B2;
       y0 += y0_err;
-      y0_err = y0 & AMSYNC_ONE;
-      y0 >>= AMSYNC_FRACTION_BITS;
-      y0 += y1;
+      y0_err = y0 & AMSYNC_FILT_ONE;
+      y0 >>= AMSYNC_FILT_BITS;
+      y0 += 2 * y1 - y2;
+      y2 = y1;
       y1 = y0;
-      x1 = err;
+      x2 = x1;
+      x1 = phi_err;
       phase_locked += y0;
 
       phase_locked = wrap(phase_locked);

--- a/simulations/am_sync_des.py
+++ b/simulations/am_sync_des.py
@@ -2,35 +2,43 @@ import math
 import cmath
 
 import numpy as np
-import scipy.signal as sig
-
 import matplotlib.pyplot as plt
 from cffi import FFI
 
 
-SR = 480000 // 32
+SR = 15000
 BASE_BITS = 15
 BASE_MAX = (1 << BASE_BITS) - 1
 
-FIX_ONE_BITS = 16
+FIX_ONE_BITS = 15
 FIX_MAX = (1 << (FIX_ONE_BITS + 3)) - 1  # times 8 to accommodate 2*pi
 FIX_ONE = (1 << FIX_ONE_BITS) - 1
 FIX_PI = round(FIX_ONE * np.pi)
 FIX_ERR_SCALE = round(FIX_PI / BASE_MAX)
 FIX_PHI_SCALE = round(16 / (((BASE_MAX) / (2 * FIX_PI))))
 
+FILT_BITS = 15
+FILT_ONE = (1 << FILT_BITS) - 1
+
 
 SRC = """
-// PLL loop bandwidth: 50Hz
-#define AMSYNC_B0 (1956)
-#define AMSYNC_B1 (-1927)
-#define AMSYNC_PI (205884)
-#define AMSYNC_ONE (65535)
-#define AMSYNC_MAX (524287)
-#define AMSYNC_ERR_SCALE (6)
-#define AMSYNC_PHI_SCALE (201)
-#define AMSYNC_FRACTION_BITS (16)
+// PLL loop bandwidth: 30Hz
+#define AMSYNC_NUM_TAPS (3)
+#define AMSYNC_B0 (1160)
+#define AMSYNC_B1 (-2306)
+#define AMSYNC_B2 (1146)
+#define AMSYNC_A0 (32767)
+#define AMSYNC_A1 (-65534)
+#define AMSYNC_A2 (32767)
+#define AMSYNC_PI (102941)
+#define AMSYNC_ONE (32767)
+#define AMSYNC_MAX (262143)
+#define AMSYNC_ERR_SCALE (3)
+#define AMSYNC_PHI_SCALE (101)
+#define AMSYNC_FRACTION_BITS (15)
 #define AMSYNC_BASE_FRACTION_BITS (15)
+#define AMSYNC_FILT_BITS (15)
+#define AMSYNC_FILT_ONE (32767)
 
 static int16_t sin_table[2048];
 
@@ -44,35 +52,63 @@ void initialise_luts(void)
   }
 }
 
-int16_t rectangular_2_phase(int16_t i, int16_t q)
-{
-   //handle condition where phase is unknown
-   if(i==0 && q==0) return 0;
+#define CORDIC_ITERS (6)
 
-   const int16_t absi=i>0?i:-i;
-   int16_t angle=0;
-   if (q>=0)
-   {
-      //scale r so that it lies in range -8192 to 8192
-      const int16_t r = ((int32_t)(q - absi) << 13) / (q + absi);
-      angle = 8192 - r;
-   }
-   else
-   {
-      //scale r so that it lies in range -8192 to 8192
-      const int16_t r = ((int32_t)(q + absi) << 13) / (absi - q);
-      angle = (3 * 8192) - r;
-   }
+static const uint32_t CORDIC_GAIN = 39803;
+static int16_t CORDIC_ATAN_LUT[CORDIC_ITERS] = {8192, 4836, 2555, 1297, 651, 326};
 
-   //angle lies in range -32768 to 32767
-   if (i < 0) return(-angle);     // negate if in quad III or IV
-   else return(angle);
+void rectangular_2_polar(int16_t i, int16_t q, uint16_t *mag, int16_t *phase) {
+  int16_t temp_i;
+  int16_t angle = 0;
+
+  if (i < 0) {
+    // rotate by an initial +/- 90 degrees
+    temp_i = i;
+    if (q > 0.0f) {
+      i = q; // subtract 90 degrees
+      q = -temp_i;
+      angle = 16384;
+    } else {
+      i = -q; // add 90 degrees
+      q = temp_i;
+      angle = -16384;
+    }
+  }
+
+  for (uint16_t k = 0; k < CORDIC_ITERS; k++) {
+    temp_i = i;
+    if (q > 0) {
+      /* Rotate clockwise */
+      i += (q >> k);
+      q -= (temp_i >> k);
+      angle += CORDIC_ATAN_LUT[k];
+    } else {
+      /* Rotate counterclockwise */
+      i -= (q >> k);
+      q += (temp_i >> k);
+      angle -= CORDIC_ATAN_LUT[k];
+    }
+  }
+
+  *mag = ((uint32_t)i * CORDIC_GAIN) >> 16;
+  *phase = angle;
+}
+
+inline int32_t wrap(int32_t x) {
+  if (x > AMSYNC_PI) {
+    x = -AMSYNC_PI + (x % AMSYNC_PI);
+  } else if (x < -AMSYNC_PI) {
+    x = AMSYNC_PI + (x % AMSYNC_PI);
+  }
+  return x;
 }
 
 void amsync_demod(int16_t *i, int16_t *q, int32_t *err) {
   static int32_t phi_locked = 0;
   static int32_t x1 = 0;
   static int32_t y1 = 0;
+  static int32_t x2 = 0;
+  static int32_t y2 = 0;
   static int32_t y0_err = 0;
 
   size_t idx = (phi_locked / AMSYNC_PHI_SCALE);
@@ -90,28 +126,23 @@ void amsync_demod(int16_t *i, int16_t *q, int32_t *err) {
   const int16_t synced_q =
       (-*i * vco_q + *q * vco_i) >> AMSYNC_BASE_FRACTION_BITS;
 
-  *err =
-      ((int32_t)rectangular_2_phase(synced_q, synced_i) * AMSYNC_ERR_SCALE);
-  //*err = (int32_t)(atan2(synced_q, synced_i) * AMSYNC_ONE);
+  int16_t phi;
+  uint16_t mag;
+  rectangular_2_polar(synced_i, synced_q, &mag, &phi);
+  *err = (int32_t)phi * AMSYNC_ERR_SCALE;
 
-  int32_t y0 = *err * AMSYNC_B0 + x1 * AMSYNC_B1;
+  int32_t y0 = *err * AMSYNC_B0 + x1 * AMSYNC_B1 + x2 * AMSYNC_B2;
   y0 += y0_err;
-  y0_err = y0 & AMSYNC_ONE;
-  y0 >>= AMSYNC_FRACTION_BITS;
-  y0 += y1;
+  y0_err = y0 & AMSYNC_FILT_ONE;
+  y0 >>= AMSYNC_FILT_BITS;  
+  y0 += 2 * y1 - y2;
+  y2 = y1;
   y1 = y0;
+  x2 = x1;
   x1 = *err;
   phi_locked += y0;
 
-  if(phi_locked > (2 * AMSYNC_PI))
-  {
-    phi_locked -= 2 * AMSYNC_PI;
-  }
-
-  if(phi_locked < (-2 * AMSYNC_PI))
-  {
-    phi_locked += 2 * AMSYNC_PI;
-  }
+  phi_locked = wrap(phi_locked);
 
   *i = vco_i;
   *q = vco_q;
@@ -139,7 +170,7 @@ def rectangular_2_phase(i, q):
         return angle
 
 
-def pll_des(loop_bw):
+def pll_2nd_order_des(loop_bw):
     # prewarping
     wa = (2 * SR) * math.tan(2 * math.pi * loop_bw / (2 * SR))
     wn = wa / SR
@@ -149,26 +180,64 @@ def pll_des(loop_bw):
     t1 = K / (wn * wn)
     t2 = 2 * zeta / wn
 
-    b0 = (2 * t2 + 1) / (2 * t1)
-    b1 = (1 - 2 * t2) / (2 * t1)
+    bf = [(2 * t2 + 1) / (2 * t1), (1 - 2 * t2) / (2 * t1)]
+    af = [1, -1]
 
-    return b0, b1
+    return bf, af
+
+
+def pll_3rd_order_des(loop_bw):
+    # prewarping
+    wa = (2 * SR) * math.tan(2 * math.pi * loop_bw / (2 * SR))
+    wn = wa / SR
+    wn = 2 * math.pi * (loop_bw / SR)
+    # b = 1 + math.sqrt(2)  # damping 0.707, silver ratio
+    b = 2.8
+    c = b
+
+    bf = (
+        b * wn**2 / 2 + c * wn + wn**3 / 4,
+        -2 * c * wn + wn**3 / 2,
+        -b * wn**2 / 2 + c * wn + wn**3 / 4,
+    )
+    af = [1, -2, 1]
+
+    return bf, af
+
 
 class PLL:
+
     def __init__(self, loop_bw):
-        self.b0, self.b1 = pll_des(loop_bw)
+        self.bf, self.af = pll_3rd_order_des(loop_bw)
+        print(self.bf, self.af)
+        self.num_taps = len(self.bf)
+
+        if len(self.bf) < 3:
+            self.bf += [0] * (3 - len(self.bf))
+
+        if len(self.af) < 3:
+            self.af += [0] * (3 - len(self.af))
 
         self.phi_locked = 0.0
-
         self.y1 = 0
         self.x1 = 0
+        self.y2 = 0
+        self.x2 = 0
 
     def process(self, i, q):
         out = complex(math.cos(self.phi_locked), math.sin(self.phi_locked))
         err = cmath.phase(complex(i, q) * complex(out.real, -out.imag))
 
-        y0 = err * self.b0 + self.x1 * self.b1 + self.y1
+        y0 = (
+            err * self.bf[0]
+            + self.x1 * self.bf[1]
+            + self.x2 * self.bf[2]
+            - self.y1 * self.af[1]
+            - self.y2 * self.af[2]
+        )
+        self.y2 = self.y1
         self.y1 = y0
+        self.x2 = self.x1
         self.x1 = err
         self.phi_locked += y0
 
@@ -189,17 +258,24 @@ class PLL:
 class PLLFixed:
     def __init__(self, loop_bw):
 
-        self.b0, self.b1 = pll_des(loop_bw)
+        self.bf, self.af = pll_3rd_order_des(loop_bw)
+        self.num_taps = len(self.bf)
 
-        self.b0 = round(self.b0 * FIX_ONE)
-        self.b1 = round(self.b1 * FIX_ONE)
+        if len(self.bf) < 3:
+            self.bf += [0] * (3 - len(self.bf))
 
-        self.phi_locked = 0
-        self.y0_err = 0
-        self.x_err = 0
+        if len(self.af) < 3:
+            self.af += [0] * (3 - len(self.af))
 
-        self.y1 = 0
-        self.x1 = 0
+        self.bf = list(map(lambda x: round(x * FILT_ONE), self.bf))
+        self.af = list(map(lambda x: round(x * FILT_ONE), self.af))
+
+        self.phi_locked = np.int32(0)
+        self.y1 = np.int32(0)
+        self.x1 = np.int32(0)
+        self.y2 = np.int32(0)
+        self.x2 = np.int32(0)
+        self.y0_err = np.int32(0)
 
         self.sin_table = []
         for idx in range(2048):
@@ -222,12 +298,17 @@ class PLLFixed:
         err = np.int32((rectangular_2_phase(tmp_q, tmp_i) * FIX_ERR_SCALE))
         # err = np.int64(round(FIX_ONE * np.angle(tmp_i + 1j * tmp_q)))
 
-        y0 = err * self.b0 + self.x1 * self.b1
+        y0 = np.int32(err * self.bf[0] + self.x1 * self.bf[1] + self.x2 * self.bf[2])
         y0 += self.y0_err
-        self.y0_err = y0 & FIX_ONE
-        y0 >>= FIX_ONE_BITS
-        y0 += self.y1
+        self.y0_err = y0 & FILT_ONE
+        y0 >>= FILT_BITS
+        if self.num_taps == 3:
+            y0 += 2 * self.y1 - self.y2
+        else:
+            y0 += self.y1
+        self.y2 = self.y1
         self.y1 = y0
+        self.x2 = self.x1
         self.x1 = err
         self.phi_locked += y0
 
@@ -261,7 +342,7 @@ def floating_sim(loop_bw, time, input):
 
     plt.plot(time, input1, label="input real")
     plt.plot(time, np.real(output), label="output real")
-    plt.plot(time, error, label="phase error")
+    # plt.plot(time, error, label="phase error")
 
     plt.grid(True)
     plt.legend()
@@ -272,8 +353,11 @@ def fixed_sim(loop_bw, time, input):
     pll = PLLFixed(loop_bw)
 
     print(f"// PLL loop bandwidth: {loop_bw}Hz")
-    print(f"#define AMSYNC_B0 ({pll.b0})")
-    print(f"#define AMSYNC_B1 ({pll.b1})")
+    print(f"#define AMSYNC_NUM_TAPS ({pll.num_taps})")
+    for i in range(pll.num_taps):
+        print(f"#define AMSYNC_B{i} ({pll.bf[i]})")
+    for i in range(pll.num_taps):
+        print(f"#define AMSYNC_A{i} ({pll.af[i]})")
     print(f"#define AMSYNC_PI ({FIX_PI})")
     print(f"#define AMSYNC_ONE ({FIX_ONE})")
     print(f"#define AMSYNC_MAX ({FIX_MAX})")
@@ -281,6 +365,8 @@ def fixed_sim(loop_bw, time, input):
     print(f"#define AMSYNC_PHI_SCALE ({FIX_PHI_SCALE})")
     print(f"#define AMSYNC_FRACTION_BITS ({FIX_ONE_BITS})")
     print(f"#define AMSYNC_BASE_FRACTION_BITS ({BASE_BITS})")
+    print(f"#define AMSYNC_FILT_BITS ({FILT_BITS})")
+    print(f"#define AMSYNC_FILT_ONE ({FILT_ONE})")
 
     output = []
     error = []
@@ -296,7 +382,7 @@ def fixed_sim(loop_bw, time, input):
 
     plt.plot(time, input1, label="input real")
     plt.plot(time, np.real(output), label="output real")
-    plt.plot(time, error, label="phase error")
+    # plt.plot(time, error, label="phase error")
 
     plt.grid(True)
     plt.legend()
@@ -335,27 +421,30 @@ def c_fixed_sim(time, input):
 
     plt.plot(time, input1, label="input real")
     plt.plot(time, np.real(output), label="output real")
-    plt.plot(time, error, label="phase error")
+    # plt.plot(time, error, label="phase error")
 
     plt.grid(True)
     plt.legend()
     plt.show()
 
+def get_noise(amp, length):
+    return np.random.random(length) * 2 * amp - amp
 
 if __name__ == "__main__":
     end = 0.8
     time = np.arange(0, end, 1 / SR)
-    # freq = np.linspace(10, 100, len(time))
-    freq = 50 + 10 * np.sin(2 * np.pi * 3 * time)
+    # freq = 80 # constant frequency
+    freq = np.linspace(10, 80, len(time)) # linearly changing frequency
+    # freq = 50 + 10 * np.sin(2 * np.pi * 3 * time) # varying frequency
     phase = 2 * np.pi * freq * time + 10
+    # introduce some phase jumps
     phase += (time > (end / 4)) * 1
     phase -= (time > (end / 2)) * 1
     phase += (time > (3 * end / 4)) * 1
-    input_a = 0.3 * np.exp(1j * phase)
-    input_a += (
-        np.random.random(len(time)) * 0.01 + 1j * np.random.random(len(time)) * 0.01
-    )
+    # to really see the PLL performance, test with low SNR signal
+    input_a = 0.1 * np.exp(1j * phase)
+    input_a += get_noise(0.01, len(time)) + 1j * get_noise(0.01, len(time))
 
-    floating_sim(50, time, input_a)
-    fixed_sim(50, time, input_a)
+    floating_sim(30, time, input_a)
+    fixed_sim(30, time, input_a)
     c_fixed_sim(time, input_a)


### PR DESCRIPTION
Not much increase computing power, but should perform even better than the previous PLL. Also lowered the loop bandwidth. 3rd-order loop is effectively a FLL (Frequency Locked Loop), can track continuous changes in frequency. Here is a plot of phase error when input changes frequency linearly:

![dpll_phase_err](https://github.com/user-attachments/assets/3f0db42a-80d2-410e-8767-a8cb84ca1b1d)

3rd-order PLL has no lag an locks faster.