### PR TITLE
Return to COLA property of the window

### DIFF
--- a/fft_filter.h
+++ b/fft_filter.h
@@ -53,7 +53,7 @@ class fft_filter
   {
     fft_initialise();
     for (uint16_t i = 0; i < fft_size; i++) {
-      const float multiplier = 0.5 * (1 - cosf(2 * M_PI * i / (fft_size - 1)));
+      const float multiplier = 0.5 * (1 - cosf(2 * M_PI * i / fft_size));
       window[i] = float2fixed(multiplier);
     }
     for (uint16_t i = 0; i < fft_size/2u; i++) {


### PR DESCRIPTION
This reverts my previous change. Sorry about that...
<img width="640" height="480" alt="win_not_cola" src="https://github.com/user-attachments/assets/6223f12f-08e8-4af3-aac7-ab101a16a9c0" />
<img width="640" height="480" alt="win_cola" src="https://github.com/user-attachments/assets/02d64692-b027-4984-8e22-e79b7a5995af" />

