### PR TITLE
Added experimental wavelet-based audio denoiser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ set(PICORX_SRCS
     ${CMAKE_CURRENT_LIST_DIR}/codecs/cordic.cpp
     ${CMAKE_CURRENT_LIST_DIR}/fault.c
     ${CMAKE_CURRENT_LIST_DIR}/m0FaultDispatch.c
+    ${CMAKE_CURRENT_LIST_DIR}/wavelet_denoiser.cpp
 )
 
 set(PICORX_LIBS

--- a/rx.cpp
+++ b/rx.cpp
@@ -319,6 +319,9 @@ void rx::apply_settings()
 
       stream_raw_iq = settings_to_apply.stream_raw_iq;
 
+      //apply wavelet denoiser threshold
+      rx_dsp_inst.set_wavelet_threshold(settings_to_apply.wavelet_threshold);
+
       settings_changed = false;
       sem_release(&settings_semaphore);
    }

--- a/rx.h
+++ b/rx.h
@@ -55,6 +55,7 @@ struct rx_settings
   uint8_t tuning_option;
   bool enable_external_nco;
   bool stream_raw_iq;
+  uint8_t wavelet_threshold;
 };
 
 struct rx_status

--- a/rx_dsp.h
+++ b/rx_dsp.h
@@ -47,6 +47,7 @@ class rx_dsp
   uint32_t get_iq_buffer_level();
   float get_tuning_offset_Hz();
   void amsync_reset(void);
+  void set_wavelet_threshold(uint8_t wt);
 
   private:
 
@@ -128,6 +129,8 @@ class rx_dsp
 
   //squelch
   int16_t squelch_threshold=0;
+  bool squelch_adaptive;
+  bool voice_activity;
   int16_t s9_threshold=0;
   uint32_t squelch_time_ms = 0;
   uint32_t squelch_timeout_ms = 0;
@@ -148,6 +151,9 @@ class rx_dsp
 
   // synchronous AM demodulator state
   amsync_t amsync;
+
+  // wavelet denoiser threshold
+  uint8_t wavelet_threshold;
 
 };
 

--- a/settings.cpp
+++ b/settings.cpp
@@ -44,6 +44,7 @@ void apply_settings_to_rx(rx & receiver, rx_settings & rx_settings, s_settings &
   rx_settings.stream_raw_iq = settings.global.usb_stream;
   rx_settings.tuning_option = settings.global.tuning_option;
   rx_settings.impulse_threshold = settings.global.impulse_threshold;
+  rx_settings.wavelet_threshold = settings.global.wavelet_threshold;
   receiver.release();
 }
 

--- a/settings.h
+++ b/settings.h
@@ -79,6 +79,7 @@ struct s_global_settings
   uint8_t aux_view;
   uint8_t tuning_option;
   uint8_t impulse_threshold;
+  uint8_t wavelet_threshold;
   bool    usb_stream;
   bool    enable_auto_notch;
   bool    iq_correction;
@@ -113,7 +114,7 @@ const s_settings default_settings = {
 }, {
   5,  //volume
   10, //cw_sidetone = 1000Hz
-  0,  //squelch_threshold
+  1,  //squelch_threshold
   0,  //squelch_timeout = never
   2,  //spectrum_zoom
   0,  //deemphasis
@@ -152,6 +153,7 @@ const s_settings default_settings = {
   2,  //tuning_option
   0,  //impulse blanker threshold
   0,  //usb_stream
+  0,  // wavelet_threshold
   0,  //enable_auto_notch
   0,  //iq_correction
   0,  //enable_noise_reduction

--- a/ui.cpp
+++ b/ui.cpp
@@ -2239,7 +2239,7 @@ bool ui::main_menu(bool & ok)
       if (menu_entry("Menu",
                      "Frequency#Recall#Store#Volume#Mode#AGC#AGC "
                      "Gain#Bandwidth#Squelch#Squelch\nTimeout#Noise\nReduction#"
-                     "Impulse\nBlanker#Auto "
+                     "Impulse\nBlanker#Audio\nDenoiser#Auto "
                      "Notch#De-\nEmphasis#Bass#Treble#IQ\nCorrection#Spectrum#"
                      "Aux\nDisplay#Band Start#Band Stop#Frequency\nStep#CW "
                      "Tone\nFrequency#USB Stream#HW Config#",
@@ -2297,7 +2297,7 @@ bool ui::main_menu(bool & ok)
             if(changed) apply_settings(false);
             break;
           case 8 :
-            done = enumerate_entry("Squelch", "S0#S1#S2#S3#S4#S5#S6#S7#S8#S9#S9+10dB#S9+20dB#S9+30dB#", settings.global.squelch_threshold, ok, changed);
+            done = enumerate_entry("Squelch", "Adaptive#S0#S1#S2#S3#S4#S5#S6#S7#S8#S9#S9+10dB#S9+20dB#S9+30dB#", settings.global.squelch_threshold, ok, changed);
             if(changed) apply_settings(false);
             break;
           case 9 :
@@ -2312,47 +2312,51 @@ bool ui::main_menu(bool & ok)
             if(changed) apply_settings(false);
             break;
           case 12:
-            done = bit_entry("Auto Notch", "Off#On#", settings.global.enable_auto_notch, ok);
+            done = enumerate_entry("Audio\nDenoiser", "Off#1#2#3#4#5#6#", settings.global.wavelet_threshold, ok, changed);
+            if(changed) apply_settings(false);
             break;
           case 13 :
+            done = bit_entry("Auto Notch", "Off#On#", settings.global.enable_auto_notch, ok);
+            break;
+          case 14 :
             done = enumerate_entry("De-\nemphasis", "Off#50us#75us#", settings.global.deemphasis, ok, changed);
             if(changed) apply_settings(false);
             break;
-          case 14 :
+          case 15 :
             done = enumerate_entry("Bass", "Off#+5dB#+10dB#+15dB#+20dB#", settings.global.bass, ok, changed);
             if(changed) apply_settings(false);
             break;
-          case 15 :
+          case 16 :
             done = enumerate_entry("Treble", "Off#+5dB#+10dB#+15dB#+20dB#", settings.global.treble, ok, changed);
             if(changed) apply_settings(false);
             break;
-          case 16 :
+          case 17 :
             done = bit_entry("IQ\nCorrection", "Off#On#", settings.global.iq_correction, ok);
             break;
-          case 17 :
+          case 18 :
             done = spectrum_menu(ok);
             break;
-          case 18:
+          case 19:
             done = enumerate_entry("Aux\nDisplay", "Waterfall#SSTV#", settings.global.aux_view, ok, changed);
             break;
-          case 19 :
+          case 20 :
             done = frequency_entry("Band Start", settings.channel.min_frequency, ok);
             break;
-          case 20 :
+          case 21 :
             done = frequency_entry("Band Stop", settings.channel.max_frequency, ok);
             break;
-          case 21 :
+          case 22 :
             done = enumerate_entry("Frequency\nStep", "10Hz#50Hz#100Hz#500Hz#1kHz#5kHz#6.25kHz#9kHz#10kHz#12.5kHz#25kHz#50kHz#100kHz#", settings.channel.step, ok, changed);
             settings.channel.frequency -= settings.channel.frequency%step_sizes[settings.channel.step];
             break;
-          case 22 :
+          case 23 :
             done = number_entry("CW Tone\nFrequency", "%iHz", 1, 30, 100, settings.global.cw_sidetone, ok, changed);
             if(changed) apply_settings(false);
             break;
-          case 23 :
+          case 24 :
             done = bit_entry("USB\nStream", "Audio#Raw IQ#", settings.global.usb_stream, ok);
             break;
-          case 24 :
+          case 25 :
             done = configuration_menu(ok);
             break;
         }

--- a/wavelet_denoiser.cpp
+++ b/wavelet_denoiser.cpp
@@ -1,0 +1,297 @@
+// Copyright (c) Mariusz Ryndzionek 2025
+// https://github.com/mryndzionek
+// License: MIT
+//
+
+#include "wavelet_denoiser.h"
+
+#include <assert.h>
+#include <math.h>
+#include <pico.h>
+
+#include <climits>
+#include <cstdio>
+
+typedef int16_t s_num_t;
+typedef int32_t d_num_t;
+
+#define FRAME_LEN (64 + 16)
+#define OVERLAP_LEN (16)
+
+#define LEVELS (3)
+#define CD_LEN_ALL (101)
+
+#define MAX_THRESHOLD_LEVEL (6)
+
+#define extra_bits (6)
+
+#define HN (16)
+
+#define ULONG_BITS (sizeof(unsigned long) * CHAR_BIT)
+
+#define FINEST_LEVEL_DETAIL_LEN (23)  // last element of CD_LEN_LUT
+
+#if 1
+// sym8 wavelet filters
+static const s_num_t H_LO[HN] = {62,    -10,   -490,  125,   1610,  -892,
+                                 -1702, 11942, 25466, 15773, -2008, -4695,
+                                 249,   1039,  -18,   -111};
+static const s_num_t H_HI[HN] = {-111,  18,     1039,  -249, -4695, 2008,
+                                 15773, -25466, 11942, 1702, -892,  -1610,
+                                 125,   490,    -10,   -62};
+static const s_num_t H_LO_INV[HN] = {-111,  -18,   1039,  249,   -4695, -2008,
+                                     15773, 25466, 11942, -1702, -892,  1610,
+                                     125,   -490,  -10,   62};
+static const s_num_t H_HI_INV[HN] = {-62,  -10,   490,    125,   -1610, -892,
+                                     1702, 11942, -25466, 15773, 2008,  -4695,
+                                     -249, 1039,  18,     -111};
+#else
+// db8 wavelet filters
+static const s_num_t H_LO[HN] = {1783, 10252, 22138, 19180, -519, -9306,
+                                 15,   4219,  -569,  -1445, 458,  287,
+                                 -160, -13,   22,    -4};
+static const s_num_t H_HI[HN] = {-4,    -22,    -13,   160,  287,   -458,
+                                 -1445, 569,    4219,  -15,  -9306, 519,
+                                 19180, -22138, 10252, -1783};
+static const s_num_t H_LO_INV[HN] = {-4,    22,    -13,   -160, 287,   458,
+                                     -1445, -569,  4219,  15,   -9306, -519,
+                                     19180, 22138, 10252, 1783};
+static const s_num_t H_HI_INV[HN] = {-1783, 10252, -22138, 19180, 519,  -9306,
+                                     -15,   4219,  569,    -1445, -458, 287,
+                                     160,   -13,   -22,    -4};
+#endif
+
+// one-sided cosine window
+static const int16_t WIN[OVERLAP_LEN] = {
+    0,     358,   1416,  3129,  5421,  8192,  11321, 14671,
+    18096, 21446, 24575, 27346, 29638, 31351, 32409, 32767};
+
+static const s_num_t CD_LEN_LUT[LEVELS] = {47, 31, 23};
+static const s_num_t CD_INV_LEN_LUT[LEVELS] = {31, 47, 79};
+
+static uint8_t g_threshold = 0;
+
+static inline d_num_t product(s_num_t a, s_num_t b) {
+  return ((d_num_t)a * b) >> (15 - extra_bits);
+}
+
+static inline d_num_t __time_critical_func(mac)(s_num_t const *const x,
+                                                s_num_t const *const h,
+                                                uint16_t n) {
+  d_num_t accum = 0;
+
+  for (uint16_t i = 0; i < 2 * n; i += 2) {
+    accum += product(x[i], h[i]);
+  }
+
+  return accum / (1 << extra_bits);
+}
+
+static inline d_num_t __time_critical_func(mac_inv)(s_num_t const *const x,
+                                                    s_num_t const *const h,
+                                                    uint16_t n) {
+  d_num_t accum = 0;
+
+  for (uint16_t i = 0; i < n; i++) {
+    accum += product(x[i], h[2 * i]);
+  }
+
+  return accum / (1 << extra_bits);
+}
+
+static void __time_critical_func(convolve)(s_num_t const *const x, uint16_t xn,
+                                           s_num_t const *const h, uint16_t hn,
+                                           s_num_t *y) {
+  for (uint16_t i = 0; i < 2 * xn; i += 2) {
+    if (i + 2 * hn > 2 * xn) {
+      y[i] = mac(&x[i], h, xn - (i / 2));
+    } else {
+      y[i] = mac(&x[i], h, hn);
+    }
+  }
+}
+
+static void __time_critical_func(convolve_inv)(s_num_t const *const x,
+                                               uint16_t xn,
+                                               s_num_t const *const h,
+                                               uint16_t hn, s_num_t *y) {
+  for (uint16_t i = 0; i < xn; i++) {
+    if (i + hn > xn) {
+      y[2 * i] = mac_inv(&x[i], h, xn - i);
+    } else {
+      y[2 * i] = mac_inv(&x[i], h, hn);
+    }
+  }
+}
+
+static void dwt(s_num_t const *const x, uint16_t xn, s_num_t const *const h_lo,
+                s_num_t const *const h_hi, uint16_t hn, s_num_t *ca,
+                s_num_t *cd) {
+  convolve(&x[0], xn / 2, &h_lo[0], hn / 2, &ca[0]);
+  convolve(&x[1], xn / 2, &h_lo[1], hn / 2, &ca[1]);
+  convolve(&x[0], xn / 2, &h_hi[0], hn / 2, &cd[0]);
+  convolve(&x[1], xn / 2, &h_hi[1], hn / 2, &cd[1]);
+  for (uint16_t i = 0; i < (xn / 2) - 1; i++) {
+    ca[i] = ca[2 * (i + 1)] + ca[2 * (i + 1) + 1];
+    cd[i] = cd[2 * (i + 1)] + cd[2 * (i + 1) + 1];
+  }
+}
+
+static void idwt(s_num_t const *const ca, s_num_t const *const cd, uint16_t cn,
+                 s_num_t const *const h_lo, s_num_t const *const h_hi,
+                 uint16_t hn, s_num_t *x) {
+  s_num_t tmp_x[2 * 47];
+
+  convolve_inv(ca, cn, &h_lo[0], hn / 2, &x[1]);
+  convolve_inv(ca, cn, &h_lo[1], hn / 2, &x[0]);
+  convolve_inv(cd, cn, &h_hi[0], hn / 2, &tmp_x[1]);
+  convolve_inv(cd, cn, &h_hi[1], hn / 2, &tmp_x[0]);
+
+  for (uint16_t i = 0; i < 2 * cn; i++) {
+    x[i] += tmp_x[i];
+  }
+}
+
+static void dwtn(s_num_t *const x, uint16_t xn, s_num_t const *const h_lo,
+                 s_num_t const *const h_hi, uint16_t hn, s_num_t *ca,
+                 s_num_t *cd) {
+  uint16_t idx = 0;
+  static s_num_t _ca[FRAME_LEN + HN];
+  static s_num_t _cd[FRAME_LEN + HN];
+
+  for (uint16_t i = 0; i < LEVELS; i++) {
+    dwt(x, xn, h_lo, h_hi, hn, _ca, _cd);
+    xn = CD_LEN_LUT[i];
+    // use approx. as new input
+    idx += xn;
+    for (uint16_t j = 0; j < xn; j++) {
+      x[hn + j] = _ca[j];                 // first [hn] is pad
+      cd[CD_LEN_ALL - idx + j] = _cd[j];  // store details
+    }
+    xn += hn;
+    if (xn % 2 == 1) {
+      x[xn++] = 0;
+    }
+  }
+
+  for (uint16_t i = 0; i < CD_LEN_LUT[LEVELS - 1]; i++) {
+    ca[i] = _ca[i];
+  }
+}
+
+static void idwtn(s_num_t *const ca, s_num_t *const cd, uint16_t cn,
+                  s_num_t const *const h_lo, s_num_t const *const h_hi,
+                  uint16_t hn, s_num_t *x) {
+  s_num_t const *cd_p = cd;
+
+  for (uint16_t i = 0; i < LEVELS; i++) {
+    idwt(ca, cd_p, cn, h_lo, h_hi, hn, x);
+    cd_p += cn;
+    cn = CD_INV_LEN_LUT[i];
+    for (uint16_t j = 0; j < cn; j++) {
+      ca[j] = x[j];
+    }
+  }
+}
+
+static inline void __time_critical_func(soft_threshold)(s_num_t *data,
+                                                        d_num_t thr,
+                                                        uint16_t n) {
+  for (uint16_t i = 0; i < n; i++) {
+    if (abs(data[i]) < thr) {
+      data[i] = 0;
+    } else if (data[i] > 0) {
+      data[i] -= thr;
+    } else {
+      data[i] += thr;
+    }
+  }
+}
+
+static inline int _cmp(const void *a, const void *b) {
+  if (*(uint16_t *)a > *(uint16_t *)b) {
+    return -1;
+  }
+  if (*(uint16_t *)a < *(uint16_t *)b) {
+    return 1;
+  }
+  return 0;
+}
+
+static s_num_t estimate_noise_level(s_num_t x[FINEST_LEVEL_DETAIL_LEN]) {
+  static uint32_t avg = 0;
+
+  for (uint16_t i = 0; i < FINEST_LEVEL_DETAIL_LEN; i++) {
+    avg += abs(x[i]) - avg / (2048);
+  }
+
+  const s_num_t sigma = avg / (2048);
+  return sigma;
+}
+
+void wavelet_set_threshold(uint8_t thres) {
+  if (thres > MAX_THRESHOLD_LEVEL) {
+    thres = MAX_THRESHOLD_LEVEL;
+  }
+
+  g_threshold = thres;
+}
+
+bool wavelet_denoise(int16_t audio[64], bool output_denoised) {
+  static s_num_t prev_in[OVERLAP_LEN];
+  static s_num_t prev_out[OVERLAP_LEN];
+  static d_num_t y1 = 0;
+
+  s_num_t x[FRAME_LEN + HN] = {0};
+  s_num_t ca[FRAME_LEN + HN] = {0};
+  s_num_t cd[CD_LEN_ALL] = {0};
+
+  for (uint16_t i = 0; i < OVERLAP_LEN; i++) {
+    x[HN + i] = prev_in[i];
+  }
+
+  for (uint16_t i = 0; i < 64; i++) {
+    x[HN + i + OVERLAP_LEN] = audio[i];
+  }
+
+  for (uint16_t i = 0; i < OVERLAP_LEN; i++) {
+    prev_in[i] = audio[64 - OVERLAP_LEN + i];
+  }
+
+  dwtn(x, FRAME_LEN + HN, H_LO, H_HI, HN, ca, cd);
+
+  d_num_t ca_sum = 0;
+  d_num_t cd_sum = 0;
+  for (uint16_t i = 0; i < FINEST_LEVEL_DETAIL_LEN; i++) {
+    ca_sum += ca[i] * ca[i];
+    cd_sum += cd[i] * cd[i];
+  }
+
+  if (output_denoised) {
+    const d_num_t sigma = estimate_noise_level(cd);
+    const d_num_t threshold = ((1 << g_threshold) * sigma) >> 1;  // VisuShrink?
+    soft_threshold(cd, threshold, CD_LEN_ALL);  // soft threshold
+    idwtn(ca, cd, CD_LEN_LUT[LEVELS - 1], H_LO_INV, H_HI_INV, HN, x);
+
+    for (uint16_t i = 0; i < OVERLAP_LEN; i++) {
+      // blend overlaps
+      prev_out[i] = ((d_num_t)prev_out[i] * (32767 - WIN[i])) >> 15;
+      x[i] = prev_out[i] + (((d_num_t)x[i] * WIN[i]) >> 15);
+      prev_out[i] = x[FRAME_LEN - OVERLAP_LEN + i];
+    }
+
+    for (uint16_t i = 0; i < 64; i++) {
+      audio[i] = x[i];
+    }
+  }
+
+  d_num_t x0 = ca_sum > cd_sum ? ((ca_sum - cd_sum) >> 4) : 0;
+  if (x0 > 32767) {
+    x0 = 32767;
+  }
+  const d_num_t y0 = y1 + ((x0 - y1) >> 4);
+  y1 = y0;
+
+  return ((y0 > 2500) ||
+          (x0 > 5000));  // TODO adjust this threshold, or make it configurable?
+}

--- a/wavelet_denoiser.h
+++ b/wavelet_denoiser.h
@@ -1,0 +1,11 @@
+// Copyright (c) Mariusz Ryndzionek 2025
+// https://github.com/mryndzionek
+// License: MIT
+//
+
+#pragma once
+
+#include <stdint.h>
+
+bool wavelet_denoise(int16_t audio[64], bool output_denoised);
+void wavelet_set_threshold(uint8_t tres);


### PR DESCRIPTION
This is an experimental wavelet-based audio denoiser. Some details are not 100% aligned with theory, but changes were needed to make it work with streaming data. The performance varies, but in many cases improves the listening experience, especially on SSB. I recommend using it with squelch, as the effect on AGCed noise is not that good.  This denoiser works directly on the audio data, so can be paired with the existing noise reductor. The option in the menu is called `Audio Denoiser`. The numeric values indicate the threshold. The higher the threshold, the more noise is removed, but the risk of signal degradation also gets higher.

The PR also implements an adaptive squelch based on wavelet approximation and detail coefficients ratio.