### PR TITLE
Small refactor

### DIFF
--- a/fft_filter.h
+++ b/fft_filter.h
@@ -1,9 +1,9 @@
-//  _  ___  _   _____ _     _                 
-// / |/ _ \/ | |_   _| |__ (_)_ __   __ _ ___ 
+//  _  ___  _   _____ _     _
+// / |/ _ \/ | |_   _| |__ (_)_ __   __ _ ___
 // | | | | | |   | | | '_ \| | '_ \ / _` / __|
 // | | |_| | |   | | | | | | | | | | (_| \__ \.
 // |_|\___/|_|   |_| |_| |_|_|_| |_|\__, |___/
-//                                  |___/    
+//                                  |___/
 //
 // Copyright (c) Jonathan P Dawson 2024
 // filename: fft_filter.h
@@ -21,14 +21,15 @@
 
 struct s_filter_control
 {
-  uint16_t start_bin; 
-  uint16_t stop_bin; 
+  uint16_t start_bin;
+  uint16_t stop_bin;
   int16_t fft_bin;
   int8_t noise_smoothing;
   int8_t noise_threshold;
   uint8_t spectrum_smoothing;
-  bool lower_sideband; 
-  bool upper_sideband; 
+  uint32_t magnitude_sum;
+  bool lower_sideband;
+  bool upper_sideband;
   bool capture;
   bool enable_auto_notch;
   bool enable_noise_reduction;

--- a/noise_reduction.cpp
+++ b/noise_reduction.cpp
@@ -62,12 +62,15 @@ static const uint32_t adaptive_threshold_lut[] = {
 };
 
 
-void noise_reduction(int16_t i[], int16_t q[], int32_t noise_estimate[], int16_t signal_estimate[], uint16_t start, uint16_t stop, const int8_t noise_smoothing, const int8_t threshold)
+void noise_reduction(int16_t i[], int16_t q[], uint16_t mag[],
+                     int32_t noise_estimate[], int16_t signal_estimate[],
+                     uint16_t start, uint16_t stop,
+                     const int8_t noise_smoothing, const int8_t threshold)
 {
     for(uint16_t idx = start; idx <= stop; ++idx)
     {
 
-      const int32_t magnitude = rectangular_2_magnitude(i[idx], q[idx]);
+      const int32_t magnitude = mag[idx];
       int32_t signal_level = signal_estimate[idx];
       int32_t noise_level = noise_estimate[idx];
 

--- a/noise_reduction.h
+++ b/noise_reduction.h
@@ -2,6 +2,9 @@
 #define __NOISE_REDUCTION_H__
 
 #include <cstdint>
-void noise_reduction(int16_t i[], int16_t q[], int32_t noise_estimate[], int16_t signal_estimate[], uint16_t start, uint16_t stop, const int8_t noise_smoothing, const int8_t threshold);
+void noise_reduction(int16_t i[], int16_t q[], uint16_t mag[],
+                     int32_t noise_estimate[], int16_t signal_estimate[],
+                     uint16_t start, uint16_t stop,
+                     const int8_t noise_smoothing, const int8_t threshold);
 
 #endif

--- a/rx_dsp.cpp
+++ b/rx_dsp.cpp
@@ -215,7 +215,6 @@ uint16_t __not_in_flash_func(rx_dsp :: process_block)(uint16_t samples[], int16_
 {
 
   uint16_t decimated_index = 0;
-  int32_t magnitude_sum = 0;
   int16_t iq[2 * adc_block_size / cic_decimation_rate];
 
   for(uint16_t idx=0; idx<adc_block_size; idx++)
@@ -293,7 +292,6 @@ uint16_t __not_in_flash_func(rx_dsp :: process_block)(uint16_t samples[], int16_
     uint16_t magnitude;
     int16_t _phase;
     rectangular_2_polar(i, q, &magnitude, &_phase);
-    magnitude_sum += magnitude;
 
     // Impulse noise blanker
     apply_impulse_blanker(i, q, magnitude);
@@ -344,7 +342,7 @@ uint16_t __not_in_flash_func(rx_dsp :: process_block)(uint16_t samples[], int16_
   }
 
   //average over the number of samples
-  signal_amplitude = (magnitude_sum * decimation_rate)/adc_block_size;
+  signal_amplitude = (filter_control.magnitude_sum * decimation_rate)/adc_block_size;
 
   return adc_block_size/decimation_rate;
 }


### PR DESCRIPTION
 Small refactor in preparation for other denoising methods:
 - record signal magnitude before denoising
 - store the computed magnitudes in local array for future use
 - pass the stored magnitudes to noise reduction to avoid magnitude recomputation