### PR TITLE
pico-sdk 2.1.1 and 2.2.0 don't work

### DIFF
--- a/BUILD.rst
+++ b/BUILD.rst
@@ -43,6 +43,13 @@ Follow the `Getting started with the Raspberry Pi Pico <https://datasheets.raspb
   chmod +x pico_setup.sh
   ./pico_setup.sh
 
+**NOTE**: pico-sdk versions 2.1.1 and 2.2.0 both use version 0.18.0 of
+the tinyusb library, and a bug in that version of tinyusb prevents the
+PicoRx firmware from running correctly. Use pico-sdk 2.1.0, or pico-sdk
+2.2.0 with the tinyusb submodule updated to version 0.19.0. If you choose
+not to install pico-sdk in your build environment, cmake will download
+a known-good version of pico-sdk into your build directory automatically.
+
 Build Project
 -------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # FetchContent to pull down the SDK sources from GitHub.
 if(NOT DEFINED ENV{PICO_SDK_PATH})
     set(ENV{PICO_SDK_FETCH_FROM_GIT} "1")
-    set(ENV{PICO_SDK_FETCH_FROM_GIT_TAG} "2.2.0")
+    set(ENV{PICO_SDK_FETCH_FROM_GIT_TAG} "2.1.0")
     set(ENV{PICOTOOL_FORCE_FETCH_FROM_GIT} "1")
     set(ENV{PICOTOOL_FETCH_FROM_GIT_PATH} "${CMAKE_BINARY_DIR}/picotool-build")
 endif()


### PR DESCRIPTION
Warn the user in the BUILD instructions, and pick a known-good version (2.1.0) in the CMakeLists.