### PR TITLE
Upgrade to tinyusb version 0.21.0

### DIFF
--- a/rx.cpp
+++ b/rx.cpp
@@ -455,9 +455,27 @@ void rx::read_batt_temp()
   }
 }
 
+static void on_usb_audio_tx_ready()
+{
+  static uint32_t start_ms = 0;
+  uint32_t curr_ms = time_us_64() / 1000;
+  if (start_ms == curr_ms)
+    return; // not enough time
+  start_ms = curr_ms;
+
+  uint16_t _usb_buf[SAMPLE_BUFFER_SIZE] = {0};
+  const uint16_t s = ring_buffer_get_num_bytes(&usb_ring_buffer);
+  if (s >= sizeof(_usb_buf))
+  {
+    ring_buffer_pop(&usb_ring_buffer, (uint8_t *)_usb_buf, sizeof(_usb_buf));
+    usb_audio_device_write(_usb_buf, sizeof(_usb_buf));
+  }
+}
+
 static bool __not_in_flash_func(usb_callback)(repeating_timer_t *rt)
 {
   (void)rt;
+  on_usb_audio_tx_ready();
   usb_audio_device_task();
   return true; // keep repeating
 }
@@ -479,14 +497,6 @@ static void on_usb_set_mutevol(bool mute, int16_t vol)
   usb_volume = 32767 * powf(10, (float)vol / (20 * 256));
   usb_mute = mute;
   critical_section_exit(&usb_volumute);
-}
-
-static void on_usb_audio_tx_ready()
-{
-  uint16_t _usb_buf[SAMPLE_BUFFER_SIZE] = {0};
-
-  ring_buffer_pop(&usb_ring_buffer, (uint8_t *)_usb_buf, sizeof(_usb_buf));
-  usb_audio_device_write(_usb_buf, sizeof(_usb_buf));
 }
 
 //thread safe method to get raw IQ data
@@ -542,15 +552,11 @@ void rx::run()
 {
     usb_audio_device_init();
     critical_section_init(&usb_volumute);
-    usb_audio_device_set_tx_ready_handler(on_usb_audio_tx_ready);
     usb_audio_device_set_mutevol_handler(on_usb_set_mutevol);
     repeating_timer_t usb_timer;
     hard_assert(pool);
 
-    // here the delay theoretically should be 1067 (1ms = 1 / (15000 / 16))
-    // however the 'usb_microphone_task' should be called more often, but not too often
-    // to save compute
-    bool ret = alarm_pool_add_repeating_timer_us(pool, 1067 / 2, usb_callback, NULL, &usb_timer);
+    bool ret = alarm_pool_add_repeating_timer_us(pool, 500, usb_callback, NULL, &usb_timer);
     hard_assert(ret);
 
     while(true)

--- a/tusb_config.h
+++ b/tusb_config.h
@@ -103,7 +103,8 @@ extern "C" {
 #define CFG_TUD_AUDIO_ENABLE_EP_IN                                    1
 #define CFG_TUD_AUDIO_FUNC_1_N_BYTES_PER_SAMPLE_TX                    2                                       // Driver gets this info from the descriptors - we define it here to use it to setup the descriptors and to do calculations with it below
 #define CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX                            2                                       // Driver gets this info from the descriptors - we define it here to use it to setup the descriptors and to do calculations with it below - be aware: for different number of channels you need another descriptor!
-#define CFG_TUD_AUDIO_EP_SZ_IN                                        TUD_AUDIO_EP_SIZE(CFG_TUD_AUDIO_FUNC_1_SAMPLE_RATE, CFG_TUD_AUDIO_FUNC_1_N_BYTES_PER_SAMPLE_TX, CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX)
+#define CFG_TUD_AUDIO_EP_SZ_IN                                        TUD_AUDIO_EP_SIZE(TUD_OPT_HIGH_SPEED, CFG_TUD_AUDIO_FUNC_1_SAMPLE_RATE, \
+                                                                                        CFG_TUD_AUDIO_FUNC_1_N_BYTES_PER_SAMPLE_TX, CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX)
 #define CFG_TUD_AUDIO_FUNC_1_EP_IN_SZ_MAX                             CFG_TUD_AUDIO_EP_SZ_IN                  // Maximum EP IN size for all AS alternate settings used
 #define CFG_TUD_AUDIO_FUNC_1_EP_IN_SW_BUF_SZ                          (TUD_OPT_HIGH_SPEED ? 16 : 2) * CFG_TUD_AUDIO_EP_SZ_IN
 

--- a/usb_audio_device.c
+++ b/usb_audio_device.c
@@ -49,10 +49,9 @@ uint32_t sampFreq;
 uint8_t clkValid;
 
 // Range states
-audio_control_range_2_n_t(1) volumeRng[CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX+1]; 			// Volume range state
-audio_control_range_4_n_t(1) sampleFreqRng; 						// Sample frequency range state
+audio20_control_range_2_n_t(1) volumeRng[CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX+1]; 			// Volume range state
+audio20_control_range_4_n_t(1) sampleFreqRng; 						// Sample frequency range state
 
-static usb_audio_device_tx_ready_handler_t usb_audio_device_tx_ready_handler = NULL;
 static usb_audio_device_mutevol_handler_t usb_audio_device_mutevol_handler = NULL;
 
 /*------------- MAIN -------------*/
@@ -68,11 +67,6 @@ void usb_audio_device_init()
   sampleFreqRng.subrange[0].bMin = USB_A_SAMPLE_RATE;
   sampleFreqRng.subrange[0].bMax = USB_A_SAMPLE_RATE;
   sampleFreqRng.subrange[0].bRes = 0;
-}
-
-void usb_audio_device_set_tx_ready_handler(usb_audio_device_tx_ready_handler_t handler)
-{
-  usb_audio_device_tx_ready_handler = handler;
 }
 
 void usb_audio_device_set_mutevol_handler(usb_audio_device_mutevol_handler_t handler)
@@ -101,7 +95,7 @@ bool tud_audio_set_req_ep_cb(uint8_t rhport, tusb_control_request_t const * p_re
   (void) pBuff;
 
   // We do not support any set range requests here, only current value requests
-  TU_VERIFY(p_request->bRequest == AUDIO_CS_REQ_CUR);
+  TU_VERIFY(p_request->bRequest == AUDIO20_CS_REQ_CUR);
 
   // Page 91 in UAC2 specification
   uint8_t channelNum = TU_U16_LOW(p_request->wValue);
@@ -120,7 +114,7 @@ bool tud_audio_set_req_itf_cb(uint8_t rhport, tusb_control_request_t const * p_r
   (void) pBuff;
 
   // We do not support any set range requests here, only current value requests
-  TU_VERIFY(p_request->bRequest == AUDIO_CS_REQ_CUR);
+  TU_VERIFY(p_request->bRequest == AUDIO20_CS_REQ_CUR);
 
   // Page 91 in UAC2 specification
   uint8_t channelNum = TU_U16_LOW(p_request->wValue);
@@ -146,18 +140,18 @@ bool tud_audio_set_req_entity_cb(uint8_t rhport, tusb_control_request_t const * 
   (void) itf;
 
   // We do not support any set range requests here, only current value requests
-  TU_VERIFY(p_request->bRequest == AUDIO_CS_REQ_CUR);
+  TU_VERIFY(p_request->bRequest == AUDIO20_CS_REQ_CUR);
 
   // If request is for our feature unit
   if ( entityID == 2 )
   {
     switch ( ctrlSel )
     {
-      case AUDIO_FU_CTRL_MUTE:
+      case AUDIO20_FU_CTRL_MUTE:
         // Request uses format layout 1
-        TU_VERIFY(p_request->wLength == sizeof(audio_control_cur_1_t));
+        TU_VERIFY(p_request->wLength == sizeof(audio20_control_cur_1_t));
 
-        mute[channelNum] = ((audio_control_cur_1_t*) pBuff)->bCur;
+        mute[channelNum] = ((audio20_control_cur_1_t*) pBuff)->bCur;
 
         TU_LOG2("    Set Mute: %d of channel: %u\r\n", mute[channelNum], channelNum);
 //        printf("    Set Mute: %d of channel: %u\r\n", mute[channelNum], channelNum);
@@ -168,11 +162,11 @@ bool tud_audio_set_req_entity_cb(uint8_t rhport, tusb_control_request_t const * 
 
       return true;
 
-      case AUDIO_FU_CTRL_VOLUME:
+      case AUDIO20_FU_CTRL_VOLUME:
         // Request uses format layout 2
-        TU_VERIFY(p_request->wLength == sizeof(audio_control_cur_2_t));
+        TU_VERIFY(p_request->wLength == sizeof(audio20_control_cur_2_t));
 
-        volume[channelNum] = ((audio_control_cur_2_t*) pBuff)->bCur;
+        volume[channelNum] = ((audio20_control_cur_2_t*) pBuff)->bCur;
 
         TU_LOG2("    Set Volume: %d dB of channel: %u\r\n", volume[channelNum], channelNum);
 //        printf("    Set Volume: %d dB of channel: %u\r\n", volume[channelNum], channelNum);
@@ -240,10 +234,10 @@ bool tud_audio_get_req_entity_cb(uint8_t rhport, tusb_control_request_t const * 
   {
     switch (ctrlSel)
     {
-      case AUDIO_TE_CTRL_CONNECTOR:;
+      case AUDIO20_TE_CTRL_CONNECTOR:;
       // The terminal connector control only has a get request with only the CUR attribute.
 
-      audio_desc_channel_cluster_t ret;
+      audio20_desc_channel_cluster_t ret;
 
       // Those are dummy values for now
       ret.bNrChannels = 1;
@@ -264,24 +258,24 @@ bool tud_audio_get_req_entity_cb(uint8_t rhport, tusb_control_request_t const * 
   {
     switch (ctrlSel)
     {
-      case AUDIO_FU_CTRL_MUTE:
+      case AUDIO20_FU_CTRL_MUTE:
 	// Audio control mute cur parameter block consists of only one byte - we thus can send it right away
 	// There does not exist a range parameter block for mute
 	TU_LOG2("    Get Mute of channel: %u\r\n", channelNum);
 	return tud_control_xfer(rhport, p_request, &mute[channelNum], 1);
 
-      case AUDIO_FU_CTRL_VOLUME:
+      case AUDIO20_FU_CTRL_VOLUME:
 
 	switch (p_request->bRequest)
 	{
-	  case AUDIO_CS_REQ_CUR:
+	  case AUDIO20_CS_REQ_CUR:
 	    TU_LOG2("    Get Volume of channel: %u\r\n", channelNum);
 	    return tud_control_xfer(rhport, p_request, &volume[channelNum], sizeof(volume[channelNum]));
-	  case AUDIO_CS_REQ_RANGE:
+	  case AUDIO20_CS_REQ_RANGE:
 	    TU_LOG2("    Get Volume range of channel: %u\r\n", channelNum);
 
 	    // Copy values - only for testing - better is version below
-	    audio_control_range_2_n_t(1) ret;
+	    audio20_control_range_2_n_t(1) ret;
 
 	    ret.wNumSubRanges = 1;
 	    ret.subrange[0].bMin = -VOLUME_CTRL_50_DB;  // -50 dB
@@ -304,16 +298,16 @@ bool tud_audio_get_req_entity_cb(uint8_t rhport, tusb_control_request_t const * 
   {
     switch (ctrlSel)
     {
-      case AUDIO_CS_CTRL_SAM_FREQ:
+      case AUDIO20_CS_CTRL_SAM_FREQ:
 
 	// channelNum is always zero in this case
 
 	switch (p_request->bRequest)
 	{
-	  case AUDIO_CS_REQ_CUR:
+	  case AUDIO20_CS_REQ_CUR:
 	    TU_LOG2("    Get Sample Freq.\r\n");
 	    return tud_control_xfer(rhport, p_request, &sampFreq, sizeof(sampFreq));
-	  case AUDIO_CS_REQ_RANGE:
+	  case AUDIO20_CS_REQ_RANGE:
 	    TU_LOG2("    Get Sample Freq. range\r\n");
 	    return tud_control_xfer(rhport, p_request, &sampleFreqRng, sizeof(sampleFreqRng));
 
@@ -321,7 +315,7 @@ bool tud_audio_get_req_entity_cb(uint8_t rhport, tusb_control_request_t const * 
 	  default: TU_BREAKPOINT(); return false;
 	}
 
-	  case AUDIO_CS_CTRL_CLK_VALID:
+	  case AUDIO20_CS_CTRL_CLK_VALID:
 	    // Only cur attribute exists for this request
 	    TU_LOG2("    Get Sample Freq. valid\r\n");
 	    return tud_control_xfer(rhport, p_request, &clkValid, sizeof(clkValid));
@@ -333,21 +327,6 @@ bool tud_audio_get_req_entity_cb(uint8_t rhport, tusb_control_request_t const * 
 
   TU_LOG2("  Unsupported entity: %d\r\n", entityID);
   return false; 	// Yet not implemented
-}
-
-bool tud_audio_tx_done_pre_load_cb(uint8_t rhport, uint8_t itf, uint8_t ep_in, uint8_t cur_alt_setting)
-{
-  (void) rhport;
-  (void) itf;
-  (void) ep_in;
-  (void) cur_alt_setting;
-
-  if (usb_audio_device_tx_ready_handler)
-  {
-    usb_audio_device_tx_ready_handler();
-  }
-
-  return true;
 }
 
 bool tud_audio_tx_done_post_load_cb(uint8_t rhport, uint16_t n_bytes_copied, uint8_t itf, uint8_t ep_in, uint8_t cur_alt_setting)

--- a/usb_audio_device.h
+++ b/usb_audio_device.h
@@ -23,7 +23,6 @@ extern "C"
     typedef void (*usb_audio_device_mutevol_handler_t)(bool, int16_t);
 
     void usb_audio_device_init();
-    void usb_audio_device_set_tx_ready_handler(usb_audio_device_tx_ready_handler_t handler);
     void usb_audio_device_set_mutevol_handler(usb_audio_device_mutevol_handler_t handler);
     void usb_audio_device_task();
     uint16_t usb_audio_device_write(const void *data, uint16_t len);

--- a/usb_descriptors.h
+++ b/usb_descriptors.h
@@ -1,50 +1,48 @@
 #ifndef _USB_DESCRIPTORS_H_
 #define _USB_DESCRIPTORS_H_
 
-#define TUD_AUDIO_PICORX_DESC_LEN (TUD_AUDIO_DESC_IAD_LEN\
-  + TUD_AUDIO_DESC_STD_AC_LEN\
-  + TUD_AUDIO_DESC_CS_AC_LEN\
-  + TUD_AUDIO_DESC_CLK_SRC_LEN\
-  + TUD_AUDIO_DESC_INPUT_TERM_LEN\
-  + TUD_AUDIO_DESC_OUTPUT_TERM_LEN\
-  + TUD_AUDIO_DESC_FEATURE_UNIT_TWO_CHANNEL_LEN\
-  + TUD_AUDIO_DESC_STD_AS_INT_LEN\
-  + TUD_AUDIO_DESC_STD_AS_INT_LEN\
-  + TUD_AUDIO_DESC_CS_AS_INT_LEN\
-  + TUD_AUDIO_DESC_TYPE_I_FORMAT_LEN\
-  + TUD_AUDIO_DESC_STD_AS_ISO_EP_LEN\
-  + TUD_AUDIO_DESC_CS_AS_ISO_EP_LEN)
-
-#define TUD_AUDIO_PICORX_DESC_N_AS_INT 1 	// Number of AS interfaces
+#define TUD_AUDIO_PICORX_DESC_LEN (TUD_AUDIO20_DESC_IAD_LEN\
+  + TUD_AUDIO20_DESC_STD_AC_LEN\
+  + TUD_AUDIO20_DESC_CS_AC_LEN\
+  + TUD_AUDIO20_DESC_CLK_SRC_LEN\
+  + TUD_AUDIO20_DESC_INPUT_TERM_LEN\
+  + TUD_AUDIO20_DESC_OUTPUT_TERM_LEN\
+  + TUD_AUDIO20_DESC_FEATURE_UNIT_LEN(2)\
+  + TUD_AUDIO20_DESC_STD_AS_LEN\
+  + TUD_AUDIO20_DESC_STD_AS_LEN\
+  + TUD_AUDIO20_DESC_CS_AS_INT_LEN\
+  + TUD_AUDIO20_DESC_TYPE_I_FORMAT_LEN\
+  + TUD_AUDIO20_DESC_STD_AS_ISO_EP_LEN\
+  + TUD_AUDIO20_DESC_CS_AS_ISO_EP_LEN)
 
 #define TUD_AUDIO_PICORX_DESCRIPTOR(_itfnum, _stridx, _nBytesPerSample, _nBitsUsedPerSample, _epin, _epsize) \
   /* Standard Interface Association Descriptor (IAD) */\
-  TUD_AUDIO_DESC_IAD(/*_firstitf*/ _itfnum, /*_nitfs*/ 0x02, /*_stridx*/ 0x00),\
+  TUD_AUDIO20_DESC_IAD(/*_firstitf*/ _itfnum, /*_nitfs*/ 0x02, /*_stridx*/ 0x00),\
   /* Standard AC Interface Descriptor(4.7.1) */\
-  TUD_AUDIO_DESC_STD_AC(/*_itfnum*/ _itfnum, /*_nEPs*/ 0x00, /*_stridx*/ _stridx),\
+  TUD_AUDIO20_DESC_STD_AC(/*_itfnum*/ _itfnum, /*_nEPs*/ 0x00, /*_stridx*/ _stridx),\
   /* Class-Specific AC Interface Header Descriptor(4.7.2) */\
-  TUD_AUDIO_DESC_CS_AC(/*_bcdADC*/ 0x0200, /*_category*/ AUDIO_FUNC_MICROPHONE, /*_totallen*/ TUD_AUDIO_DESC_CLK_SRC_LEN+TUD_AUDIO_DESC_INPUT_TERM_LEN+TUD_AUDIO_DESC_OUTPUT_TERM_LEN+TUD_AUDIO_DESC_FEATURE_UNIT_TWO_CHANNEL_LEN, /*_ctrl*/ AUDIO_CS_AS_INTERFACE_CTRL_LATENCY_POS),\
+  TUD_AUDIO20_DESC_CS_AC(/*_bcdADC*/ 0x0200, /*_category*/ AUDIO20_FUNC_MICROPHONE, /*_totallen*/ TUD_AUDIO20_DESC_CLK_SRC_LEN+TUD_AUDIO20_DESC_INPUT_TERM_LEN+TUD_AUDIO20_DESC_OUTPUT_TERM_LEN+TUD_AUDIO20_DESC_FEATURE_UNIT_LEN(2), /*_ctrl*/ AUDIO20_CS_AS_INTERFACE_CTRL_LATENCY_POS),\
   /* Clock Source Descriptor(4.7.2.1) */\
-  TUD_AUDIO_DESC_CLK_SRC(/*_clkid*/ 0x04, /*_attr*/ AUDIO_CLOCK_SOURCE_ATT_INT_FIX_CLK, /*_ctrl*/ (AUDIO_CTRL_R << AUDIO_CLOCK_SOURCE_CTRL_CLK_FRQ_POS), /*_assocTerm*/ 0x01,  /*_stridx*/ 0x00),\
+  TUD_AUDIO20_DESC_CLK_SRC(/*_clkid*/ 0x04, /*_attr*/ AUDIO20_CLOCK_SOURCE_ATT_INT_FIX_CLK, /*_ctrl*/ (AUDIO20_CTRL_R << AUDIO20_CLOCK_SOURCE_CTRL_CLK_FRQ_POS), /*_assocTerm*/ 0x01,  /*_stridx*/ 0x00),\
   /* Input Terminal Descriptor(4.7.2.4) */\
-  TUD_AUDIO_DESC_INPUT_TERM(/*_termid*/ 0x01, /*_termtype*/ AUDIO_TERM_TYPE_IN_GENERIC_MIC, /*_assocTerm*/ 0x03, /*_clkid*/ 0x04, /*_nchannelslogical*/ 0x02, /*_channelcfg*/ AUDIO_CHANNEL_CONFIG_NON_PREDEFINED, /*_idxchannelnames*/ 0x00, /*_ctrl*/ AUDIO_CTRL_R << AUDIO_IN_TERM_CTRL_CONNECTOR_POS, /*_stridx*/ 0x00),\
+  TUD_AUDIO20_DESC_INPUT_TERM(/*_termid*/ 0x01, /*_termtype*/ AUDIO_TERM_TYPE_IN_GENERIC_MIC, /*_assocTerm*/ 0x03, /*_clkid*/ 0x04, /*_nchannelslogical*/ 0x02, /*_channelcfg*/ AUDIO20_CHANNEL_CONFIG_NON_PREDEFINED, /*_idxchannelnames*/ 0x00, /*_ctrl*/ AUDIO20_CTRL_R << AUDIO20_IN_TERM_CTRL_CONNECTOR_POS, /*_stridx*/ 0x00),\
   /* Output Terminal Descriptor(4.7.2.5) */\
-  TUD_AUDIO_DESC_OUTPUT_TERM(/*_termid*/ 0x03, /*_termtype*/ AUDIO_TERM_TYPE_USB_STREAMING, /*_assocTerm*/ 0x01, /*_srcid*/ 0x02, /*_clkid*/ 0x04, /*_ctrl*/ 0x0000, /*_stridx*/ 0x00),\
+  TUD_AUDIO20_DESC_OUTPUT_TERM(/*_termid*/ 0x03, /*_termtype*/ AUDIO_TERM_TYPE_USB_STREAMING, /*_assocTerm*/ 0x01, /*_srcid*/ 0x02, /*_clkid*/ 0x04, /*_ctrl*/ 0x0000, /*_stridx*/ 0x00),\
   /* Feature Unit Descriptor(4.7.2.8) */\
-  TUD_AUDIO_DESC_FEATURE_UNIT_TWO_CHANNEL(/*_unitid*/ 0x02, /*_srcid*/ 0x01, /*_ctrlch0master*/ AUDIO_CTRL_RW << AUDIO_FEATURE_UNIT_CTRL_MUTE_POS | AUDIO_CTRL_RW << AUDIO_FEATURE_UNIT_CTRL_VOLUME_POS, /*_ctrlch1*/ AUDIO_CTRL_RW << AUDIO_FEATURE_UNIT_CTRL_MUTE_POS | AUDIO_CTRL_RW << AUDIO_FEATURE_UNIT_CTRL_VOLUME_POS, /*_ctrlch2*/ AUDIO_CTRL_RW << AUDIO_FEATURE_UNIT_CTRL_MUTE_POS | AUDIO_CTRL_RW << AUDIO_FEATURE_UNIT_CTRL_VOLUME_POS, /*_stridx*/ 0x00),\
+  TUD_AUDIO20_DESC_FEATURE_UNIT(/*_unitid*/ 0x02, /*_srcid*/ 0x01, /*_stridx*/ 0x00,/*_ctrlch0master*/ AUDIO20_CTRL_RW << AUDIO20_FEATURE_UNIT_CTRL_MUTE_POS | AUDIO20_CTRL_RW << AUDIO20_FEATURE_UNIT_CTRL_VOLUME_POS, /*_ctrlch1*/ AUDIO20_CTRL_RW << AUDIO20_FEATURE_UNIT_CTRL_MUTE_POS | AUDIO20_CTRL_RW << AUDIO20_FEATURE_UNIT_CTRL_VOLUME_POS, /*_ctrlch2*/ AUDIO20_CTRL_RW << AUDIO20_FEATURE_UNIT_CTRL_MUTE_POS | AUDIO20_CTRL_RW << AUDIO20_FEATURE_UNIT_CTRL_VOLUME_POS),\
   /* Standard AS Interface Descriptor(4.9.1) */\
   /* Interface 1, Alternate 0 - default alternate setting with 0 bandwidth */\
-  TUD_AUDIO_DESC_STD_AS_INT(/*_itfnum*/ (uint8_t)((_itfnum)+1), /*_altset*/ 0x00, /*_nEPs*/ 0x00, /*_stridx*/ 0x00),\
+  TUD_AUDIO20_DESC_STD_AS_INT(/*_itfnum*/ (uint8_t)((_itfnum)+1), /*_altset*/ 0x00, /*_nEPs*/ 0x00, /*_stridx*/ 0x00),\
   /* Standard AS Interface Descriptor(4.9.1) */\
   /* Interface 1, Alternate 1 - alternate interface for data streaming */\
-  TUD_AUDIO_DESC_STD_AS_INT(/*_itfnum*/ (uint8_t)((_itfnum)+1), /*_altset*/ 0x01, /*_nEPs*/ 0x01, /*_stridx*/ 0x00),\
+  TUD_AUDIO20_DESC_STD_AS_INT(/*_itfnum*/ (uint8_t)((_itfnum)+1), /*_altset*/ 0x01, /*_nEPs*/ 0x01, /*_stridx*/ 0x00),\
   /* Class-Specific AS Interface Descriptor(4.9.2) */\
-  TUD_AUDIO_DESC_CS_AS_INT(/*_termid*/ 0x03, /*_ctrl*/ AUDIO_CTRL_NONE, /*_formattype*/ AUDIO_FORMAT_TYPE_I, /*_formats*/ AUDIO_DATA_FORMAT_TYPE_I_PCM, /*_nchannelsphysical*/ 0x02, /*_channelcfg*/ AUDIO_CHANNEL_CONFIG_NON_PREDEFINED, /*_stridx*/ 0x00),\
+  TUD_AUDIO20_DESC_CS_AS_INT(/*_termid*/ 0x03, /*_ctrl*/ AUDIO20_CTRL_NONE, /*_formattype*/ AUDIO20_FORMAT_TYPE_I, /*_formats*/ AUDIO20_DATA_FORMAT_TYPE_I_PCM, /*_nchannelsphysical*/ 0x02, /*_channelcfg*/ AUDIO20_CHANNEL_CONFIG_NON_PREDEFINED, /*_stridx*/ 0x00),\
   /* Type I Format Type Descriptor(2.3.1.6 - Audio Formats) */\
-  TUD_AUDIO_DESC_TYPE_I_FORMAT(_nBytesPerSample, _nBitsUsedPerSample),\
+  TUD_AUDIO20_DESC_TYPE_I_FORMAT(_nBytesPerSample, _nBitsUsedPerSample),\
   /* Standard AS Isochronous Audio Data Endpoint Descriptor(4.10.1.1) */\
-  TUD_AUDIO_DESC_STD_AS_ISO_EP(/*_ep*/ _epin, /*_attr*/ (uint8_t) ((uint8_t)TUSB_XFER_ISOCHRONOUS | (uint8_t)TUSB_ISO_EP_ATT_ASYNCHRONOUS | (uint8_t)TUSB_ISO_EP_ATT_DATA), /*_maxEPsize*/ _epsize, /*_interval*/ 0x01),\
+  TUD_AUDIO20_DESC_STD_AS_ISO_EP(/*_ep*/ _epin, /*_attr*/ (uint8_t) ((uint8_t)TUSB_XFER_ISOCHRONOUS | (uint8_t)TUSB_ISO_EP_ATT_ASYNCHRONOUS | (uint8_t)TUSB_ISO_EP_ATT_DATA), /*_maxEPsize*/ _epsize, /*_interval*/ 0x01),\
   /* Class-Specific AS Isochronous Audio Data Endpoint Descriptor(4.10.1.2) */\
-  TUD_AUDIO_DESC_CS_AS_ISO_EP(/*_attr*/ AUDIO_CS_AS_ISO_DATA_EP_ATT_NON_MAX_PACKETS_OK, /*_ctrl*/ AUDIO_CTRL_NONE, /*_lockdelayunit*/ AUDIO_CS_AS_ISO_DATA_EP_LOCK_DELAY_UNIT_UNDEFINED, /*_lockdelay*/ 0x0000)
+  TUD_AUDIO20_DESC_CS_AS_ISO_EP(/*_attr*/ AUDIO20_CS_AS_ISO_DATA_EP_ATT_NON_MAX_PACKETS_OK, /*_ctrl*/ AUDIO20_CTRL_NONE, /*_lockdelayunit*/ AUDIO20_CS_AS_ISO_DATA_EP_LOCK_DELAY_UNIT_UNDEFINED, /*_lockdelay*/ 0x0000)
 
 #endif


### PR DESCRIPTION
Changes needed to upgrade to tinyusb  0.21.0 (latest tagged version).  `pico-sdk/lib/tinyusb` needs to be checked out to tag 0.21.0. Hopefully the previous USB enumeration problems will be gone and Windows behavior will improve.